### PR TITLE
Add Python 3 compatibility, Add Docs badge.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,8 @@ The code in this repository is a library written in Fortran with bindings for C 
 Documentation
 =============
 
-Documentation for this library is available on `readthedocs <http://lungsim.readthedocs.io/>`_.
+Documentation for this library is available on `readthedocs <http://lungsim.readthedocs.io/>`_, and the status of the documentation build is: |docs_build_badge|.
+
+.. |docs_build_badge| image:: https://readthedocs.org/projects/lungsim/badge/?version=latest
+   :target: http://lungsim.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status

--- a/cmake/sitepackagelocations.py
+++ b/cmake/sitepackagelocations.py
@@ -76,5 +76,5 @@ if sys.platform == "darwin":
                     pass
 
 
-map(lambda x: sys.stdout.write('%s\n' % x), site_packages)
-
+for site_package in site_packages:
+    sys.stdout.write('%s\n' % site_package)


### PR DESCRIPTION
Make the getsitepackages script compatible with Python 3.  Add a badge from readthedocs to show the status of the documentation build there.