### PR TITLE
Update sphinx build requirements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,4 +8,8 @@ The code in this repository is a library written in Fortran with bindings for C 
 Documentation
 =============
 
-Documentation for this library is available on `readthedocs <http://lungsim.readthedocs.io/>`_.
+Documentation for this library is available on `readthedocs <http://lungsim.readthedocs.io/>`_, and the status of the documentation build is: |docs_build_badge|.
+
+.. |docs_build_badge| image:: https://readthedocs.org/projects/lungsim/badge/?version=latest
+   :target: http://lungsim.readthedocs.io/en/latest/?badge=latest
+   :alt: Documentation Status

--- a/cmake/sitepackagelocations.py
+++ b/cmake/sitepackagelocations.py
@@ -76,5 +76,5 @@ if sys.platform == "darwin":
                     pass
 
 
-map(lambda x: sys.stdout.write('%s\n' % x), site_packages)
-
+for site_package in site_packages:
+    sys.stdout.write('%s\n' % site_package)

--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,2 +1,2 @@
-sphinx-fortran
+https://github.com/VACUMM/sphinx-fortran@c114cf738f67ec193cd9868396cb901d23420c67
 numpy


### PR DESCRIPTION
The sphinx-fortran requirement needs to be updated to work with a newer version not currently available on pypi.