### PR TITLE
bringing back allocation of node and element arrays as tehy should be

### DIFF
--- a/src/lib/geometry.f90
+++ b/src/lib/geometry.f90
@@ -2340,61 +2340,66 @@ contains
 !###################################################################################
 !
    
+!
+!#####################################################################
+!
+!*reallocate_node_elem_arrays:* Reallocates the size of arrays when modifying geometries
   subroutine reallocate_node_elem_arrays(num_elems_new,num_nodes_new)
-    
-    use arrays,only: num_nodes,nodes,num_elems,elem_nodes,elem_symmetry,node_field,&
-elem_direction,elems_at_node,expansile,elem_cnct,elem_field,elem_ordrs,dp,node_xyz,elems
-    use indices,only:num_ne,num_nj,num_ord
-    use diagnostics,only: enter_exit
+    use arrays,only: dp,elems,elem_cnct,elem_direction,elem_field,&
+         elem_ordrs,elem_nodes,&
+         elem_symmetry,elem_units_below,elems_at_node,expansile,&
+         nodes,node_field,node_xyz,num_elems,num_nodes
+    use indices
+    use diagnostics, only: enter_exit
+    implicit none
 
+!!! Parameters
     integer,intent(in) :: num_elems_new,num_nodes_new
+
+!!! Local variables
     integer,allocatable :: nodelem_temp(:),enodes_temp(:,:),enodes_temp2(:,:,:)
     real(dp),allocatable :: xyz_temp(:,:),rnodes_temp(:,:)
     logical,allocatable :: exp_temp(:)
     character(len=60) :: sub_name
-    
-    ! ###########################################################################
-    
+
     sub_name = 'reallocate_node_elem_arrays'
     call enter_exit(sub_name,1)
-    
+
     allocate(nodelem_temp(num_nodes))
     nodelem_temp = nodes ! copy to temporary array
     deallocate(nodes) !deallocate initially allocated memory
     allocate(nodes(num_nodes_new))
     nodes(1:num_nodes)=nodelem_temp(1:num_nodes)
     deallocate(nodelem_temp) !deallocate the temporary array
-    !write(*,*) 'number of nodes:',num_nodes,num_nodes_new    
+
     allocate(xyz_temp(3,num_nodes))
     xyz_temp=node_xyz
     deallocate(node_xyz)
     allocate(node_xyz(3,num_nodes_new))
     node_xyz(1:3,1:num_nodes)=xyz_temp(1:3,1:num_nodes)
-    
+
     allocate(nodelem_temp(num_elems))
     nodelem_temp = elems ! copy to temporary array
     deallocate(elems) !deallocate initially allocated memory
     allocate(elems(num_elems_new))
     elems(1:num_elems)=nodelem_temp(1:num_elems)
     deallocate(nodelem_temp) !deallocate the temporary array
-    !write(*,*) 'number of elems:',num_elems,num_elems_new
+
     allocate(enodes_temp(2,num_elems))
     enodes_temp=elem_nodes
     deallocate(elem_nodes)
     allocate(elem_nodes(2,num_elems_new))
     elem_nodes(1:2,1:num_elems)=enodes_temp(1:2,1:num_elems)
     deallocate(enodes_temp)
-    !write(*,*) 'elem field:', elem_field
-    !allocate(rnodes_temp(num_ne,num_elems))
-    !rnodes_temp=elem_field
-    !write(*,*) '1st', num_ne
-    !deallocate(elem_field)
-    !write(*,*) '2nd'
-    !allocate(elem_field(num_ne,num_elems_new))
-    !elem_field(1:num_ne,1:num_elems)=rnodes_temp(1:num_ne,1:num_elems)
-    !deallocate(rnodes_temp)
-    !elem_field(1:num_ne,num_elems+1:num_elems_new) = 0.0_dp
-    
+
+    allocate(rnodes_temp(num_ne,num_elems))
+    rnodes_temp=elem_field
+    deallocate(elem_field)
+    allocate(elem_field(num_ne,num_elems_new))
+    elem_field(1:num_ne,1:num_elems)=rnodes_temp(1:num_ne,1:num_elems)
+    deallocate(rnodes_temp)
+    elem_field(1:num_ne,num_elems+1:num_elems_new) = 0.0_dp
+
     allocate(rnodes_temp(3,num_elems))
     rnodes_temp=elem_direction
     deallocate(elem_direction)
@@ -2418,7 +2423,7 @@ elem_direction,elems_at_node,expansile,elem_cnct,elem_field,elem_ordrs,dp,node_x
     elem_symmetry(1:num_elems)=nodelem_temp(1:num_elems)
     deallocate(nodelem_temp) !deallocate the temporary array
     elem_symmetry(num_elems+1:num_elems_new)=1
-    
+
     allocate(enodes_temp2(-1:1,0:2,0:num_elems))
     enodes_temp2=elem_cnct
     deallocate(elem_cnct)
@@ -2426,7 +2431,7 @@ elem_direction,elems_at_node,expansile,elem_cnct,elem_field,elem_ordrs,dp,node_x
     elem_cnct(-1:1,0:2,0:num_elems)=enodes_temp2(-1:1,0:2,0:num_elems)
     deallocate(enodes_temp2)
     elem_cnct(-1:1,0:2,num_elems+1:num_elems_new) = 0
-    
+
     allocate(enodes_temp(num_ord,num_elems))
     enodes_temp=elem_ordrs
     deallocate(elem_ordrs)
@@ -2434,15 +2439,15 @@ elem_direction,elems_at_node,expansile,elem_cnct,elem_field,elem_ordrs,dp,node_x
     elem_ordrs(1:num_ord,1:num_elems)=enodes_temp(1:num_ord,1:num_elems)
     deallocate(enodes_temp)
     elem_ordrs(1:num_ord,num_elems+1:num_elems_new) = 0
-    
-!    allocate(nodelem_temp(num_elems))
-!    nodelem_temp=elem_units_below
-!    deallocate(elem_units_below)
-!    allocate(elem_units_below(num_elems_new))
-!    elem_units_below(1:num_elems)=nodelem_temp(1:num_elems)
-!    deallocate(nodelem_temp)
-!    elem_units_below(num_elems+1:num_elems_new)=0
-    
+
+    allocate(nodelem_temp(num_elems))
+    nodelem_temp=elem_units_below
+    deallocate(elem_units_below)
+    allocate(elem_units_below(num_elems_new))
+    elem_units_below(1:num_elems)=nodelem_temp(1:num_elems)
+    deallocate(nodelem_temp)
+    elem_units_below(num_elems+1:num_elems_new)=0
+
     allocate(enodes_temp(num_nodes,0:3))
     enodes_temp=elems_at_node
     deallocate(elems_at_node)
@@ -2450,7 +2455,7 @@ elem_direction,elems_at_node,expansile,elem_cnct,elem_field,elem_ordrs,dp,node_x
     elems_at_node(1:num_nodes,0:3)=enodes_temp(1:num_nodes,0:3)
     deallocate(enodes_temp)
     elems_at_node(num_nodes+1:num_nodes_new,0:3)=0
-    
+
     allocate(exp_temp(num_elems))
     exp_temp = expansile
     deallocate(expansile)
@@ -2460,9 +2465,8 @@ elem_direction,elems_at_node,expansile,elem_cnct,elem_field,elem_ordrs,dp,node_x
     expansile(num_elems+1:num_elems_new)=.false.
 
     call enter_exit(sub_name,2)
-    
-  end subroutine reallocate_node_elem_arrays
 
+  end subroutine reallocate_node_elem_arrays
 
 !!!###############################################################
 

--- a/src/lib/geometry.f90
+++ b/src/lib/geometry.f90
@@ -462,15 +462,17 @@ contains
     allocate(elem_field(num_ne,num_elems))
     if(allocated(elem_direction)) deallocate(elem_direction)
     allocate(elem_direction(3,num_elems))
-    if(allocated(expansile)) deallocate(expansile)
-    allocate(expansile(num_elems))
+    if(model_type.eq.'gas_mix')then
+      if(allocated(expansile)) deallocate(expansile)
+      allocate(expansile(num_elems))
+    endif
 
 !!! initialise element arrays
     elems=0
     elem_nodes=0
     elem_symmetry = 1
     elem_field = 0.0_dp
-    expansile = .false.
+    if(model_type.eq.'gas_mix')expansile = .false.
 
     ne=0
 
@@ -2277,7 +2279,7 @@ contains
         parentlist(num_parents)=ne
      endif !elem_cnct
    enddo !noelem
-   write(*,*) 'Elements distal to elem #12 are:', parentlist
+
    deallocate(templist)
 
    call enter_exit(sub_name,2)
@@ -2343,7 +2345,7 @@ contains
 !
 !#####################################################################
 !
-!*reallocate_node_elem_arrays:* Reallocates the size of arrays when modifying geometries
+!*reallocate_node_elem_arrays:* Reallocates the size of geometric arrays when modifying geometries
   subroutine reallocate_node_elem_arrays(num_elems_new,num_nodes_new)
     use arrays,only: dp,elems,elem_cnct,elem_direction,elem_field,&
          elem_ordrs,elem_nodes,&
@@ -2392,13 +2394,15 @@ contains
     elem_nodes(1:2,1:num_elems)=enodes_temp(1:2,1:num_elems)
     deallocate(enodes_temp)
 
-    allocate(rnodes_temp(num_ne,num_elems))
-    rnodes_temp=elem_field
-    deallocate(elem_field)
-    allocate(elem_field(num_ne,num_elems_new))
-    elem_field(1:num_ne,1:num_elems)=rnodes_temp(1:num_ne,1:num_elems)
-    deallocate(rnodes_temp)
-    elem_field(1:num_ne,num_elems+1:num_elems_new) = 0.0_dp
+    if(allocated(elem_field).and.num_ne.gt.0)then
+        allocate(rnodes_temp(num_ne,num_elems))
+        rnodes_temp=elem_field
+        deallocate(elem_field)
+        allocate(elem_field(num_ne,num_elems_new))
+        elem_field(1:num_ne,1:num_elems)=rnodes_temp(1:num_ne,1:num_elems)
+        deallocate(rnodes_temp)
+        elem_field(1:num_ne,num_elems+1:num_elems_new) = 0.0_dp
+    endif
 
     allocate(rnodes_temp(3,num_elems))
     rnodes_temp=elem_direction
@@ -2408,13 +2412,15 @@ contains
     deallocate(rnodes_temp)
     elem_direction(1:3,num_elems+1:num_elems_new) = 0.0_dp
 
-    allocate(rnodes_temp(num_nj,num_nodes))
-    rnodes_temp=node_field
-    deallocate(node_field)
-    allocate(node_field(num_nj,num_nodes_new))
-    node_field(1:num_nj,1:num_nodes)=rnodes_temp(1:num_nj,1:num_nodes)
-    deallocate(rnodes_temp)
-    node_field(1:num_nj,num_nodes+1:num_nodes_new)=0.0_dp
+    if(allocated(node_field).and.num_nj.gt.0)then
+      allocate(rnodes_temp(num_nj,num_nodes))
+      rnodes_temp=node_field
+      deallocate(node_field)
+      allocate(node_field(num_nj,num_nodes_new))
+      node_field(1:num_nj,1:num_nodes)=rnodes_temp(1:num_nj,1:num_nodes)
+      deallocate(rnodes_temp)
+      node_field(1:num_nj,num_nodes+1:num_nodes_new)=0.0_dp
+    endif
 
     allocate(nodelem_temp(num_elems))
     nodelem_temp = elem_symmetry ! copy to temporary array
@@ -2440,13 +2446,15 @@ contains
     deallocate(enodes_temp)
     elem_ordrs(1:num_ord,num_elems+1:num_elems_new) = 0
 
-    allocate(nodelem_temp(num_elems))
-    nodelem_temp=elem_units_below
-    deallocate(elem_units_below)
-    allocate(elem_units_below(num_elems_new))
-    elem_units_below(1:num_elems)=nodelem_temp(1:num_elems)
-    deallocate(nodelem_temp)
-    elem_units_below(num_elems+1:num_elems_new)=0
+    if(allocated(elem_units_below).and.num_nu.gt.0)then
+      allocate(nodelem_temp(num_elems))
+      nodelem_temp=elem_units_below
+      deallocate(elem_units_below)
+      allocate(elem_units_below(num_elems_new))
+      elem_units_below(1:num_elems)=nodelem_temp(1:num_elems)
+      deallocate(nodelem_temp)
+      elem_units_below(num_elems+1:num_elems_new)=0
+    endif
 
     allocate(enodes_temp(num_nodes,0:3))
     enodes_temp=elems_at_node
@@ -2456,13 +2464,15 @@ contains
     deallocate(enodes_temp)
     elems_at_node(num_nodes+1:num_nodes_new,0:3)=0
 
-    allocate(exp_temp(num_elems))
-    exp_temp = expansile
-    deallocate(expansile)
-    allocate(expansile(num_elems_new))
-    expansile(1:num_elems)=exp_temp(1:num_elems)
-    deallocate(exp_temp)
-    expansile(num_elems+1:num_elems_new)=.false.
+    if(model_type.eq.'gas_mix')then
+      allocate(exp_temp(num_elems))
+      exp_temp = expansile
+      deallocate(expansile)
+      allocate(expansile(num_elems_new))
+      expansile(1:num_elems)=exp_temp(1:num_elems)
+      deallocate(exp_temp)
+      expansile(num_elems+1:num_elems_new)=.false.
+    endif
 
     call enter_exit(sub_name,2)
 

--- a/src/lib/indices.f90
+++ b/src/lib/indices.f90
@@ -99,6 +99,9 @@ contains
       case ('ventilation')
         print *, 'You are solving a ventilation model, setting up indices'
         call ventilation_indices
+      case('grow_tree')
+        print *, 'You are solving a growing problem, setting up indices'
+        call growing_indices
     end select
     model_type=TRIM(PROBLEM_TYPE)
     call enter_exit(sub_name,2)
@@ -224,6 +227,30 @@ contains
     nu_vent=10
     call enter_exit(sub_name,2)
   end subroutine ventilation_indices
+!
+!########################################################################
+!
+!> Growing indices
+  subroutine growing_indices
+  !DEC$ ATTRIBUTES DLLEXPORT,ALIAS:"SO_GROWING_INDICES" :: GROWING_INDICES
+
+    use diagnostics, only: enter_exit
+    implicit none
+    character(len=60) :: sub_name
+
+    sub_name = 'growing_indices'
+    call enter_exit(sub_name,1)
+    ! indices for elem_ordrs. These dont usually change.
+    ! indices for node_field
+    num_nj=0 !number of nodal fields
+    ! indices for elem_field
+    num_ne=2 !number of element fields
+    ne_radius=1 !radius of airway
+    ne_length=2 !length of airway
+    ! indices for unit_field
+    num_nu=0
+    call enter_exit(sub_name,2)
+  end subroutine growing_indices
 !
 !######################################################################
 !


### PR DESCRIPTION
The reallocation of node and element arrays with a growing geometry was incorrectly changed at some point in the file history. All fields listed here need to be reallocated 