### PR TITLE
Update sphinx fortran version.

### DIFF
--- a/documentation/requirements.txt
+++ b/documentation/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/VACUMM/sphinx-fortran@056c500a1f0bfdc90c740ce80e41d4983a0dc2ee
+git+https://github.com/hsorby/sphinx-fortran.git
 numpy


### PR DESCRIPTION
The version of Sphinx used by readthedocs.org has changed to version 1.4.3.  The sphinx fortran extension now does not work with that version of Sphinx.  Updating to my fork that contains fixes for Sphinx 1.4.3 will resolve the failing documentation builds.