### PR TITLE
export_1d_elem_field numbering fixed

### DIFF
--- a/src/lib/exports.f90
+++ b/src/lib/exports.f90
@@ -374,7 +374,7 @@ contains
           write(10,'( ''  #xi1=1'')')
        endif
 
-       write(10,'(1X,''Element: '',I12,'' 0 0'' )') ne
+       write(10,'(1X,''Element: '',I12,'' 0 0'' )') elems(ne)
        write(10,'(3X,''Values:'' )')
        write(10,'(4X,2(1X,E12.5))') elem_field(ne_field,ne),elem_field(ne_field,ne)
     enddo !no_nelist (ne)

--- a/src/lib/exports.f90
+++ b/src/lib/exports.f90
@@ -15,9 +15,9 @@ module exports
   use diagnostics
   use indices
   use other_consts
-  
+
   implicit none
- 
+
   private
   public &
        export_1d_elem_geometry, &
@@ -47,7 +47,7 @@ contains
     use geometry,only: coord_at_xi
     character(len=*) :: EXFILE
     character(len=*) :: groupname
-    
+
     integer,allocatable :: nodes_at_centre(:),nodes_on_lines(:), &
          node_xyz_2d_temp(:,:,:,:)
     integer,allocatable :: nodes_cl(:),nodes_cl_elems(:,:)
@@ -60,7 +60,7 @@ contains
     character(len=300) :: writefile
 
     call enter_exit(sub_name,1)
-    
+
     ! overallocating the minimum required memory, just to make indexing of nodes easy
     allocate(nodes_on_lines(num_nodes_2d+num_lines_2d))
     nodes_on_lines = 0
@@ -178,12 +178,12 @@ contains
     enddo
     close(10)
     close(20)
-    
+
     deallocate(nodes_on_lines)
     deallocate(nodes_at_centre)
     deallocate(nodes_cl_elems)
     deallocate(xyz)
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine export_cubic_lagrange_2d
@@ -202,12 +202,12 @@ contains
     character(len=1) :: char1
     character(len=100) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'export_triangle_elements'
     call enter_exit(sub_name,1)
-    
+
     if(index(EXELEMFILE, ".exelem")> 0) then !full filename is given
        writefile = EXELEMFILE(1:100)
     else ! need to append the correct filename extension
@@ -225,7 +225,7 @@ contains
        write(10,'( '' Element: 0 0 '',I5)') nline+3
        nline = nline+3
     enddo !ne
-       
+
     !**        write the elements
     write(10,'( '' Shape. Dimension=2, line*line'' )')
     write(10,'( '' #Scale factor sets=1'' )')
@@ -233,7 +233,7 @@ contains
     write(10,'( '' #Nodes= '',I2 )') 4
     write(10,'( '' #Fields=1'' )')
     write(10,'( '' 1) coordinates, coordinate, rectangular cartesian, #Components=3'')')
-       
+
     do nj = 1,3
        if(nj==1) char1='x'; if(nj==2) char1='y'; if(nj==3) char1='z';
        write(10,'(''  '',A2,''. l.Lagrange*l.Lagrange, no modify, standard node based.'')') char1
@@ -244,7 +244,7 @@ contains
           write(10,'(''     Scale factor indices: '',I4)') nn
        enddo !nn
     enddo !nj
-       
+
     nline = 0
     do ne = 1,num_triangles
        !**         write the element
@@ -268,7 +268,7 @@ contains
     call enter_exit(sub_name,2)
 
   end subroutine export_triangle_elements
-  
+
 !
 !##############################################################################
 !
@@ -283,12 +283,12 @@ contains
     integer :: i,nj
     character(len=100) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'export_triangle_nodes'
     call enter_exit(sub_name,1)
-    
+
     if(index(EXNODEFILE, ".exnode")> 0) then !full filename is given
        writefile = EXNODEFILE(1:100)
     else ! need to append the correct filename extension
@@ -316,7 +316,7 @@ contains
        write(10,'(2x,3(f12.6))') vertex_xyz(:,i)
     enddo
     close(10)
-       
+
     call enter_exit(sub_name,2)
 
   end subroutine export_triangle_nodes
@@ -338,9 +338,9 @@ contains
     logical :: CHANGED
     character(len=300) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'export_1d_elem_field'
     call enter_exit(sub_name,1)
 
@@ -349,7 +349,7 @@ contains
     else ! need to append the correct filename extension
        writefile = trim(EXELEMFILE)//'.exelem'
     endif
-    
+
     open(10, file=writefile, status='replace')
 
     len_end=len_trim(group_name)
@@ -374,7 +374,7 @@ contains
           write(10,'( ''  #xi1=1'')')
        endif
 
-       write(10,'(1X,''Element: '',I12,'' 0 0'' )') elems(ne)
+       write(10,'(1X,''Element: '',I12,'' 0 0'' )') ne
        write(10,'(3X,''Values:'' )')
        write(10,'(4X,2(1X,E12.5))') elem_field(ne_field,ne),elem_field(ne_field,ne)
     enddo !no_nelist (ne)
@@ -398,9 +398,9 @@ contains
     logical :: CHANGED
     character(len=300) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'export_1d_elem_geometry'
     call enter_exit(sub_name,1)
 
@@ -409,9 +409,9 @@ contains
     else ! need to append the correct filename extension
        writefile = trim(EXELEMFILE)//'.exelem'
     endif
-    
+
     open(10, file=writefile, status='replace')
-    
+
     len_end=len_trim(name)
     !**     write the group name
     write(10,'( '' Group name: '',A)') name(:len_end)
@@ -450,7 +450,7 @@ contains
     close(10)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine export_1d_elem_geometry
 
 !
@@ -478,7 +478,7 @@ contains
     else ! need to append the correct filename extension
        writefile = trim(EXELEMFILE)//'.exelem'
     endif
-    
+
     open(10, file=writefile, status='replace')
 
     !**     write the group name
@@ -535,7 +535,7 @@ contains
           WRITE(10,'( '' #Nodes= '',I2 )') numnodes_ex
           WRITE(10,'( '' #Fields= 1'' )')
           WRITE(10,'( '' 1) coordinates, coordinate, rectangular cartesian, #Components=3'')')
-          
+
           do nj=1,3
              if(nj==1) char1='x'; if(nj==2) char1='y'; if(nj==3) char1='z';
              WRITE(10,'(''  '',A2,''.  c.Hermite*c.Hermite, no modify, standard node based.'')') char1
@@ -589,9 +589,9 @@ contains
     logical :: FIRST_NODE
     character(len=300) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'export_node_geometry'
     call enter_exit(sub_name,1)
 
@@ -600,7 +600,7 @@ contains
     else ! need to append the correct filename extension
        writefile = trim(EXNODEFILE)//'.exnode'
     endif
-    
+
     len_end=len_trim(name)
     if(num_nodes.GT.0) THEN
        open(10, file=writefile, status='replace')
@@ -636,7 +636,7 @@ contains
     close(10)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine export_node_geometry
 
 !
@@ -663,7 +663,7 @@ contains
     else ! need to append the correct filename extension
        writefile = trim(EXNODEFILE)//'.exnode'
     endif
-    
+
     if(num_nodes_2d.gt.0)then
        open(10, file=writefile, status='replace')
 
@@ -786,9 +786,9 @@ contains
     else ! need to append the correct filename extension
        writefile = trim(EXNODEFILE)//'.exnode'
     endif
-    
+
     len_end=len_trim(name)
-    
+
     if(num_units.GT.0) THEN
        open(10, file=writefile, status='replace')
        !**     write the group name
@@ -859,7 +859,7 @@ contains
     close(10)
 
   end subroutine export_terminal_solution
-  
+
 !
 !##############################################################################
 !
@@ -997,7 +997,7 @@ contains
     close(10)
 
   end subroutine export_terminal_ssgexch
-  
+
 !
 !##############################################################################
 !

--- a/src/lib/geometry.f90
+++ b/src/lib/geometry.f90
@@ -276,7 +276,7 @@ contains
     call reallocate_node_elem_arrays(num_elems_new,num_nodes_new)
     noelem0=0
     ne0 = num_elems ! the starting local element number
-    ne_global = elems(ne0) ! assumes this is the highest element number (!!!)
+    ne_global = maxval(elems) ! assumes this is the highest element number (!!!)
     np0 = num_nodes ! the starting local node number
     np_global = nodes(np0) ! assumes this is the highest node number (!!!)
 
@@ -337,7 +337,7 @@ contains
     !update current no of nodes and elements to determine connectivity
     np0=np !current highest node
     ne1=ne !current highest element
-    noelem0=num_elems*2+noelem0
+    noelem0=maxval(elems)
     if(mesh_type.eq.'ladder')then
        !To be implemented
     elseif(mesh_type.eq.'terminal')then

--- a/src/lib/geometry.f90
+++ b/src/lib/geometry.f90
@@ -14,15 +14,15 @@ module geometry
   use mesh_utilities
   use other_consts ! currently has pi
   use precision ! sets dp for precision
-  
+
   implicit none
-  
+
   !Module parameters
-  
+
   !Module types
-  
+
   !Module variables
-  
+
   !Interfaces
   private
   public add_mesh
@@ -57,23 +57,23 @@ module geometry
   public get_four_nodes
   public write_elem_geometry_2d
   public write_node_geometry_2d
-  
+
 contains
 
 !!!#############################################################################
-  
+
   subroutine allocate_node_arrays(num_nodes)
     !*allocate_node_arrays:* allocate memory for arrays associated with 1D trees
-    
+
     integer,intent(in) :: num_nodes
     ! Local variables
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'allocate_node_arrays'
     call enter_exit(sub_name,1)
-    
+
     if(.not.allocated(nodes)) allocate (nodes(num_nodes))
     if(.not.allocated(node_xyz)) allocate (node_xyz(3,num_nodes))
     if(.not.allocated(node_field)) allocate (node_field(num_nj,num_nodes))
@@ -81,11 +81,11 @@ contains
     nodes = 0 !initialise node index values
     node_xyz = 0.0_dp !initialise
     node_field = 0.0_dp !initialise
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine allocate_node_arrays
-  
+
 !!!#############################################################################
 
   subroutine add_mesh(AIRWAY_MESHFILE)
@@ -107,21 +107,21 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'add_mesh'
     call enter_exit(sub_name,1)
 
     ios = 0
     line = 0
     open(fh, file=AIRWAY_MESHFILE)
-    
+
     ! ios is negative if an end of record condition is encountered or if
     ! an endfile condition was detected.  It is positive if an error was
     ! detected.  ios is zero otherwise.
     ios=0
     line=0
     i=0 ! count the number of elements read in
-    
+
     do while (ios == 0)
        read(fh, '(A)', iostat=ios) buffer
        ! line contains: element, parent element, generation,
@@ -131,7 +131,7 @@ contains
           line = line + 1
           i=i+1
           i_ss_end = len(buffer)
-          
+
           do nlabel = 1,7
              ibeg = index(buffer," ") + 1 !get location of first integer beyond ws in string
              buffer = adjustl(buffer(ibeg:i_ss_end)) ! get info beyond ws, remove leading ws
@@ -156,80 +156,80 @@ contains
        endif
     enddo
     close(fh)
-    
+
     num_elems_to_add = i
-    
+
 !!! increase the size of node and element arrays to accommodate the additional elements
     ! the number of nodes after adding mesh will be:
     num_nodes_new = num_nodes + num_units*num_elems_to_add
     ! the number of elems after adding mesh will be:
     num_elems_new = num_elems + num_units*num_elems_to_add
     call reallocate_node_elem_arrays(num_elems_new,num_nodes_new)
-    
+
     ne = num_elems ! the starting local element number
     ne_global = elems(ne) ! assumes this is the highest element number (!!!)
     np = num_nodes ! the starting local node number
     np_global = nodes(np) ! assumes this is the highest node number (!!!)
-    
+
     do nunit = 1,num_units ! for all terminal branches, append the mesh
-       
+
        ne_parent = units(nunit) ! local element number of terminal, to append to
        ngen_parent = elem_ordrs(1,ne_parent)
        ne_start = ne !starting element number for the unit
-       
+
        do i=1,num_elems_to_add
-          
+
           if(parent_element(i).eq.0)then
              ne_parent = units(nunit)
           else
              ne_parent = ne_start+parent_element(i)
           endif
-          
+
           ne0 = ne_parent
           np0 = elem_nodes(2,ne0)
-          
+
           ne_global = ne_global + 1 ! new global element number
           ne = ne + 1 ! new local element number
           np_global = np_global + 1 !new global node number
           np = np + 1 ! new local node number
-          
+
           nodes(np) = np_global
           elems(ne) = ne_global
-          
+
           elem_nodes(1,ne) = np0
           elem_nodes(2,ne) = np
-          
+
           elem_ordrs(1,ne) = ngen_parent + generation(i)
           elem_ordrs(no_type,ne) = 1   ! ntype ! 0 for respiratory, 1 for conducting
           elem_symmetry(ne) = symmetry_temp(i)+1 ! uses 0/1 in file; 1/2 in code
-          
+
           ! record the element connectivity
           elem_cnct(-1,0,ne) = 1 ! one parent branch
           elem_cnct(-1,1,ne) = ne0 ! store parent element
           elem_cnct(1,0,ne0) = elem_cnct(1,0,ne0) + 1
           elem_cnct(1,elem_cnct(1,0,ne0),ne0) = ne
-          
+
           ! record the direction and location of the branch
           do j=1,3
              elem_direction(j,ne) = elem_direction(j,ne0)
              node_xyz(j,np) = node_xyz(j,np0) + &
                   elem_direction(j,ne)*length(i)
           enddo !j
-          
+
           elem_field(ne_length,ne) = length(i)
           elem_field(ne_radius,ne) = radius(i)
           elem_field(ne_a_A,ne) = a_A(i)
           elem_field(ne_vol,ne) = PI*radius(i)**2*length(i)
-          
+
        enddo !i
     enddo !nunit
-    
+
     num_nodes = np
     num_elems = ne
-    
+
     call element_connectivity_1d
     call evaluate_ordering ! calculate new ordering of tree
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine add_mesh
@@ -237,7 +237,7 @@ contains
 !!!#############################################################################
 
   subroutine add_matching_mesh()
-    !*add_matching_mesh:* 
+    !*add_matching_mesh:*
 
     !Parameters to become inputs
     real(dp) :: offset(3)
@@ -252,7 +252,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'add_matching_mesh'
     call enter_exit(sub_name,1)
     !Ultimately offset should be an input argument
@@ -279,7 +279,7 @@ contains
     ne_global = elems(ne0) ! assumes this is the highest element number (!!!)
     np0 = num_nodes ! the starting local node number
     np_global = nodes(np0) ! assumes this is the highest node number (!!!)
-    
+
     do nonode=1,num_nodes
        np=np_global+nonode
        np_m=nodes(nonode)
@@ -291,7 +291,7 @@ contains
        elems_at_node(np,0)=0 !initialise
        !Doesnt map versions, would be added here
     enddo
-    
+
     do noelem=1,num_elems
        ne=ne_global+noelem
        elem_field(ne_group,ne)=2.0_dp!VEIN
@@ -333,11 +333,11 @@ contains
        nindex=no_hord
        elem_ordrs(nindex,ne)=elem_ordrs(nindex,ne_m)
     enddo
-    
+
     !update current no of nodes and elements to determine connectivity
     np0=np !current highest node
     ne1=ne !current highest element
-    noelem0=num_elems+noelem0
+    noelem0=num_elems*2+noelem0
     if(mesh_type.eq.'ladder')then
        !To be implemented
     elseif(mesh_type.eq.'terminal')then
@@ -380,7 +380,7 @@ contains
     deallocate(np_map)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine add_matching_mesh
 
 !!!#############################################################################
@@ -393,7 +393,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'append_units'
     call enter_exit(sub_name,1)
 
@@ -403,18 +403,18 @@ contains
           num_units=num_units+1
        endif
     enddo
-    
+
     if(allocated(units))then !increasing the array size; just overwrite
        deallocate(units)
        deallocate(unit_field)
     endif
     allocate(units(num_units))
     allocate(unit_field(num_nu,num_units))
-    
+
     unit_field=0.0_dp
     units=0
     elem_units_below(1:num_elems) = 0 !initialise the number of terminal units below a branch
-    
+
     nu=0
     do ne=1,num_elems
        if(elem_cnct(1,0,ne).eq.0)THEN
@@ -423,7 +423,7 @@ contains
           elem_units_below(ne)=1
        endif
     enddo
-    
+
     ! count the effective number of elements below each branch
     do ne=num_elems,2,-1
        ne0=elem_cnct(-1,1,ne)
@@ -439,7 +439,7 @@ contains
 
   subroutine define_1d_elements(ELEMFILE)
     !*define_1d_elements:* Reads in an 1D element ipelem file to define a geometry
-    
+
     character(len=MAX_FILENAME_LEN), intent(in) :: ELEMFILE
     !     Local Variables
     integer :: ibeg,iend,ierror,i_ss_end,j,ne,ne_global,&
@@ -448,20 +448,20 @@ contains
     character(len=300) :: readfile
     character(LEN=40) :: sub_string
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_1d_elements'
     call enter_exit(sub_name,1)
-    
+
     if(index(ELEMFILE, ".ipelem")> 0) then !full filename is given
        readfile = ELEMFILE
     else ! need to append the correct filename extension
        readfile = trim(ELEMFILE)//'.ipelem'
     endif
-    
+
     open(10, file=readfile, status='old')
-    
+
     read_number_of_elements : do
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1
        if(index(ctemp1, "elements")> 0) then
@@ -469,7 +469,7 @@ contains
           exit read_number_of_elements
        endif
     end do read_number_of_elements
-    
+
 !!! allocate memory for element arrays
     if(allocated(elems)) deallocate(elems)
     allocate(elems(num_elems))
@@ -493,7 +493,7 @@ contains
        if(allocated(expansile)) deallocate(expansile)
        allocate(expansile(num_elems))
     endif
-    
+
 !!! initialise element arrays
     elems = 0
     elem_nodes = 0
@@ -501,9 +501,9 @@ contains
     elem_symmetry = 1
     elem_field = 0.0_dp
     if(model_type.eq.'gas_mix')expansile = .false.
-    
+
     ne=0
-    
+
     read_an_element : do
        !.......read element number
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1
@@ -511,7 +511,7 @@ contains
           ne_global = get_final_integer(ctemp1) !return the final integer
           ne=ne+1
           elems(ne)=ne_global
-          
+
           read_element_nodes : do
              read(unit=10, fmt="(a)", iostat=ierror) ctemp1
              if(index(ctemp1, "global")> 0) then !found the correct line
@@ -532,11 +532,11 @@ contains
           end do read_element_nodes
           if(ne.ge.num_elems) exit read_an_element
        endif
-       
+
     end do read_an_element
-    
+
     close(10)
-    
+
     ! calculate the element lengths and directions
     do ne=1,num_elems
        np1=elem_nodes(1,ne)
@@ -550,12 +550,12 @@ contains
                node_xyz(j,np1))/elem_field(ne_length,ne)
        enddo !j
     enddo
-    
+
     call element_connectivity_1d
     call evaluate_ordering
 
     elem_ordrs(no_type,:) = 1 ! 0 for respiratory, 1 for conducting
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine define_1d_elements
@@ -571,20 +571,20 @@ contains
     integer :: ierror,ne,ne_global,nn,np,number_of_elements
     character(len=132) :: ctemp1,readfile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_elem_geometry_2d'
     call enter_exit(sub_name,1)
-    
+
     if(index(ELEMFILE, ".ipelem")> 0) then !full filename is given
        readfile = ELEMFILE
     else ! need to append the correct filename extension
        readfile = trim(ELEMFILE)//'.ipelem'
     endif
-    
+
     open(10, file=readfile, status='old')
-    
+
     read_number_of_elements : do
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1
        if(index(ctemp1, "elements")> 0) then
@@ -592,7 +592,7 @@ contains
           exit read_number_of_elements
        endif
     end do read_number_of_elements
-    
+
     num_elems_2d=number_of_elements
     if(allocated(elems_2d))then
        deallocate(elems_2d)
@@ -602,18 +602,18 @@ contains
     allocate(elems_2d(num_elems_2d))
     allocate(elem_nodes_2d(4,num_elems_2d))
     allocate(elem_versn_2d(4,num_elems_2d))
-    
+
     ne = 0
-    
-    read_an_element : do 
+
+    read_an_element : do
        !.......read element number
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1
        if(index(ctemp1, "Element")> 0) then
           ne_global = get_final_integer(ctemp1) !return the final integer
           ne = ne + 1
           elems_2d(ne) = ne_global
-          
-          read_element_nodes : do 
+
+          read_element_nodes : do
              read(unit=10, fmt="(a)", iostat=ierror) ctemp1
              if(index(ctemp1, "global")> 0) then !found the correct line
                 call get_four_nodes(ne,ctemp1) !number of versions for node np
@@ -632,21 +632,21 @@ contains
                 exit read_element_nodes
              endif !index
           end do read_element_nodes
-          
+
           if(ne.ge.number_of_elements) exit read_an_element
        endif
-       
+
     end do read_an_element
-    
+
     close(10)
-    
+
     call element_connectivity_2d
     call line_segments_for_2d_mesh(sf_option)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine define_elem_geometry_2d
-  
+
 !!!#############################################################################
 
   subroutine define_mesh_geometry_test()
@@ -655,15 +655,15 @@ contains
     !     Local Variables
     integer :: j,ne,np,np1,np2
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_mesh_geometry_test'
     call enter_exit(sub_name,1)
-    
+
     num_elems = 400
     num_nodes = num_elems + 1
-    
+
 !!! allocate memory
     if(.not.allocated(nodes)) allocate (nodes(num_nodes))
     if(.not.allocated(node_xyz)) allocate (node_xyz(3,num_nodes))
@@ -678,7 +678,7 @@ contains
     if(.not.allocated(elem_field)) allocate(elem_field(num_ne,num_elems))
     if(.not.allocated(elem_direction)) allocate(elem_direction(3,num_elems))
     if(.not.allocated(expansile)) allocate(expansile(num_elems))
-    
+
 !!! initialise array values
     nodes = 0 !initialise node index values
     node_xyz = 0.0_dp !initialise
@@ -688,14 +688,14 @@ contains
     elem_symmetry = 1
     elem_field = 0.0_dp
     expansile = .false.
-    
+
 !!! set up node arrays
     nodes(1) = 1
     do np=2,101
        nodes(np) = np
        node_xyz(3,np) = node_xyz(3,np-1) - 1.0_dp
     enddo
-    
+
     np=102
     node_xyz(1,np) = node_xyz(1,np-1) - 0.5_dp
     do np=102,151
@@ -703,7 +703,7 @@ contains
        node_xyz(3,np) = node_xyz(3,np-1) - 0.5_dp
        node_xyz(1,np) = node_xyz(1,np-1) - 0.5_dp
     enddo
-    
+
     np=152
     nodes(np) = np
     node_xyz(1,np) = node_xyz(1,101) + 0.5_dp
@@ -713,7 +713,7 @@ contains
        node_xyz(3,np) = node_xyz(3,np-1) - 0.5_dp
        node_xyz(1,np) = node_xyz(1,np-1) + 0.5_dp
     enddo
-    
+
     np=202
     nodes(np) = np
     node_xyz(1,np) = node_xyz(1,151) - 0.5_dp
@@ -723,7 +723,7 @@ contains
        node_xyz(3,np) = node_xyz(3,np-1) - 0.5_dp
        node_xyz(1,np) = node_xyz(1,np-1) - 0.5_dp
     enddo
-    
+
     np=252
     nodes(np) = np
     node_xyz(1,np) = node_xyz(1,151) + 0.5_dp
@@ -733,7 +733,7 @@ contains
        node_xyz(3,np) = node_xyz(3,np-1) - 0.5_dp
        node_xyz(1,np) = node_xyz(1,np-1) + 0.5_dp
     enddo
-    
+
     np=302
     nodes(np) = np
     node_xyz(1,np) = node_xyz(1,201) - 0.5_dp
@@ -743,7 +743,7 @@ contains
        node_xyz(3,np) = node_xyz(3,np-1) - 0.5_dp
        node_xyz(1,np) = node_xyz(1,np-1) - 0.5_dp
     enddo
-    
+
     np=352
     nodes(np) = np
     node_xyz(1,np) = node_xyz(1,201) + 0.5_dp
@@ -753,24 +753,24 @@ contains
        node_xyz(3,np) = node_xyz(3,np-1) - 0.5_dp
        node_xyz(1,np) = node_xyz(1,np-1) + 0.5_dp
     enddo
-    
+
 !!! set up element arrays
     do ne=1,num_elems
        elems(ne) = ne
        elem_nodes(1,ne) = ne
        elem_nodes(2,ne) = ne+1
     enddo
-    
+
     elem_nodes(1,151) = 101
     elem_nodes(1,201) = 151
     elem_nodes(1,251) = 151
     elem_nodes(1,301) = 201
     elem_nodes(1,351) = 201
-    
+
     elem_field(ne_radius,1:100) = 10.0_dp
     elem_field(ne_radius,101:200) = 5.0_dp
     elem_field(ne_radius,201:400) = sqrt(elem_field(ne_radius,101)**2/2.0_dp)
-    
+
     ! calculate the element lengths and directions
     do ne=1,num_elems
        np1=elem_nodes(1,ne)
@@ -788,19 +788,19 @@ contains
             elem_field(ne_length,ne)
        elem_field(ne_a_A,ne) = 1.0_dp ! set default for ratio a/A
     enddo
-    
+
     call element_connectivity_1d
     call evaluate_ordering
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine define_mesh_geometry_test
 
 !!!#############################################################################
-  
+
   subroutine define_node_geometry(NODEFILE)
     !*define_node_geometry:* Reads in an ipnode file to define a tree geometry
-    
+
     character(len=MAX_FILENAME_LEN), intent(in) :: NODEFILE !Input nodefile
     !     Local Variables
     integer :: i,ierror,np,np_global,num_nodes_temp,num_versions,nv,NJT=0
@@ -808,22 +808,22 @@ contains
     logical :: overwrite = .false. ! initialised
     character(len=300) :: ctemp1,readfile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_node_geometry'
     call enter_exit(sub_name,1)
-    
+
     if(index(NODEFILE, ".ipnode")> 0) then !full filename is given
        readfile = NODEFILE
     else ! need to append the correct filename extension
        readfile = trim(NODEFILE)//'.ipnode'
     endif
-    
+
     open(10, file=readfile, status='old')
-    
+
     if(num_nodes.gt.0) overwrite = .true.
-    
+
     !.....read in the total number of nodes. read each line until one is found
     !.....that has the correct keyword (nodes). then return the integer that is
     !.....at the end of the line
@@ -834,9 +834,9 @@ contains
           exit read_number_of_nodes !exit the named do loop
        endif
     end do read_number_of_nodes
-    
+
     if(.not.overwrite) call allocate_node_arrays(num_nodes_temp) ! don't allocate if just overwriting
-    
+
     !.....read in the number of coordinates
     read_number_of_coords : do !define a do loop name
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1 !read a line into ctemp1
@@ -845,17 +845,17 @@ contains
           exit read_number_of_coords !exit the named do loop
        endif
     end do read_number_of_coords
-    
-    ! note that only the first version of coordinate is currently read in   
-    
-    !.....read the coordinate, derivative, and version information for each node. 
+
+    ! note that only the first version of coordinate is currently read in
+
+    !.....read the coordinate, derivative, and version information for each node.
     np=0
     read_a_node : do !define a do loop name
        !.......read node number
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1
        if(index(ctemp1, "Node")> 0) then
           np_global = get_final_integer(ctemp1) !get node number
-          
+
           np = np+1
           nodes(np) = np_global
           !.......read coordinates
@@ -884,20 +884,20 @@ contains
        endif !index
        if(np.ge.num_nodes_temp) exit read_a_node
     end do read_a_node
-    
+
     if(.not.overwrite) num_nodes = num_nodes_temp
-    
+
     close(10)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine define_node_geometry
 
 !!!#############################################################################
 
   subroutine define_node_geometry_2d(NODEFILE)
     !*define_node_geometry_2d:* Reads in an ipnode file to define surface nodes
-    
+
     character(len=*),intent(in) :: NODEFILE
     !     Local Variables
     integer :: i,ierror,np,np_global,&
@@ -905,20 +905,20 @@ contains
     integer,parameter :: num_derivs = 3
     character(len=132) :: ctemp1,readfile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_node_geometry_2d'
     call enter_exit(sub_name,1)
-    
+
     if(index(NODEFILE, ".ipnode")> 0) then !full filename is given
        readfile = NODEFILE
     else ! need to append the correct filename extension
        readfile = trim(NODEFILE)//'.ipnode'
     endif
-    
+
     open(10, file=readfile, status='old')
-    
+
     !.....read in the total number of nodes. read each line until one is found
     !.....that has the correct keyword (nodes). then return the integer that is
     !.....at the end of the line
@@ -929,7 +929,7 @@ contains
           exit read_number_of_nodes !exit the named do loop
        endif
     end do read_number_of_nodes
-    
+
 !!!allocate memory to arrays that require node number
     if(allocated(nodes_2d))then ! deallocate
        deallocate(nodes_2d)
@@ -939,18 +939,18 @@ contains
     allocate(nodes_2d(num_nodes_2d))
     allocate(node_xyz_2d(4,10,3,num_nodes_2d))
     allocate(node_versn_2d(num_nodes_2d))
-    
-    !.....read the coordinate, derivative, and version information for each node. 
+
+    !.....read the coordinate, derivative, and version information for each node.
     np=0
     read_a_node : do !define a do loop name
        !.......read node number
        read(unit=10, fmt="(a)", iostat=ierror) ctemp1
        if(index(ctemp1, "Node")> 0) then
           np_global = get_final_integer(ctemp1) !get node number
-          
+
           np=np+1
           nodes_2d(np) = np_global
-          
+
           !.......read coordinates
           do i=1,3 ! for the x,y,z coordinates
              num_versions = 0
@@ -962,7 +962,7 @@ contains
                 if(num_versions > 1)then
                    read(unit=10, fmt="(a)", iostat=ierror) ctemp1 ! "For version number..."
                 endif
-                !...........coordinate          
+                !...........coordinate
                 if(num_versions > 0) &
                      read(unit=10, fmt="(a)", iostat=ierror) ctemp1
                 node_xyz_2d(1,nv,i,np) = get_final_real(ctemp1)
@@ -990,11 +990,11 @@ contains
        endif !index
        if(np.ge.num_nodes_2d) exit read_a_node
     end do read_a_node
-    
+
     close(10)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine define_node_geometry_2d
 
 !!!#############################################################################
@@ -1012,7 +1012,7 @@ contains
 
     sub_name = 'define_data_geometry'
     call enter_exit(sub_name,1)
-    
+
     if(index(datafile, ".ipdata")> 0) then !full filename is given
        readfile = datafile
     else ! need to append the correct filename extension
@@ -1024,7 +1024,7 @@ contains
 
     !set the counted number of data points to zero
     ncount = 0
-    
+
 !!! first run through to count the number of data points
     read_line_to_count : do
        read(unit=10, fmt="(a)", iostat=ierror) buffer
@@ -1034,33 +1034,33 @@ contains
     num_data = ncount
     close (10)
     write(*,'('' Read'',I7,'' data points from file'')') num_data
-    
+
 !!! allocate arrays now that we know the size required
     if(allocated(data_xyz)) deallocate(data_xyz)
     if(allocated(data_weight)) deallocate(data_weight)
     allocate(data_xyz(3,num_data))
     allocate(data_weight(3,num_data))
-    
+
 !!! read the data point information
     open(10, file=readfile, status='old')
     read(unit=10, fmt="(a)", iostat=ierror) buffer
-    
+
     !set the counted number of data points to zero
     ncount = 0
     read_line_of_data : do
-       
+
        ! read the data #; z; y; z; wd1; wd2; wd3 for each data point
        read(unit=10, fmt="(a)", iostat=ierror) buffer
        if(ierror<0) exit !ierror<0 means end of file
        length_string = len_trim(buffer) !length of buffer, and removed trailing blanks
-       
+
        ! read data number
        buffer=adjustl(buffer) !remove leading blanks
        iend=index(buffer," ",.false.)-1 !index returns location of first blank
        if(length_string == 0) exit
        ncount=ncount+1
        read (buffer(1:iend), '(i6)') itemp
-       
+
        do nj=1,3
           ! read x,y,z coordinates
           buffer = adjustl(buffer(iend+1:length_string)) !remove data number from string
@@ -1069,7 +1069,7 @@ contains
           iend=index(buffer," ",.false.)-1 !index returns location of first blank
           read (buffer(1:iend), '(D25.17)') data_xyz(nj,ncount)
        enddo !nj
-       
+
        do nj=1,3
           !        ! read weightings
           !        buffer = adjustl(buffer(iend+1:length_string)) !remove data number from string
@@ -1079,11 +1079,11 @@ contains
           !        read (buffer(1:iend), '(D25.17)') data_weight(nj,ncount)
           data_weight(nj,ncount)=1.0_dp
        enddo !nj
-       
+
     enddo read_line_of_data
-    
+
     close(10)
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine define_data_geometry
@@ -1093,24 +1093,24 @@ contains
   subroutine import_node_geometry_2d(NODEFILE)
     !*define_node_geometry_2d:* Reads in an exnode file to define surface nodes
     !DEC$ ATTRIBUTES DLLEXPORT,ALIAS:"SO_DEFINE_NODE_GEOMETRY_2D" :: DEFINE_NODE_GEOMETRY_2D
-    
+
     character(len=*),intent(in) :: NODEFILE
     !     Local Variables
     integer :: i,ierror,index_location,np,np_global,num_versions,nv
     character(len=132) :: ctemp1,readfile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'import_node_geometry_2d'
     call enter_exit(sub_name,1)
-    
+
     if(index(NODEFILE, ".exnode")> 0) then !full filename is given
        readfile = NODEFILE
     else ! need to append the correct filename extension
        readfile = trim(NODEFILE)//'.exnode'
     endif
-    
+
     open(10, file=readfile, status='old')
 
     !.....get the total number of nodes.
@@ -1131,8 +1131,8 @@ contains
     nodes_2d = 0
     node_xyz_2d = 0.0_dp
     node_versn_2d = 0
-    
-    !.....read the coordinate, derivative, and version information for each node. 
+
+    !.....read the coordinate, derivative, and version information for each node.
     open(10, file=readfile, status='old')
     np = 0
     num_versions = 1
@@ -1152,7 +1152,7 @@ contains
           np = np+1
           nodes_2d(np) = np_global
           node_versn_2d(np) = num_versions
-          
+
           !.......read coordinates
           do i =1,3 ! for the x,y,z coordinates
              do nv = 1,node_versn_2d(np)
@@ -1162,11 +1162,11 @@ contains
        endif !index
        if(np.ge.num_nodes_2d) exit read_a_node
     end do read_a_node
-    
+
     close(10)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine import_node_geometry_2d
 
 !!!#############################################################################
@@ -1181,24 +1181,24 @@ contains
     integer :: i,ibeg,iend,ierror,nt,nv
     character(len=132) :: string,readfile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'import_ply_triangles'
     call enter_exit(sub_name,1)
-    
+
     if(index(ply_file, ".ply")> 0) then !full filename is given
        readfile = ply_file
     else ! need to append the correct filename extension
        readfile = trim(ply_file)//'.ply'
     endif
-    
+
     open(10, file=readfile, status='old')
 
     !.....get the total number of vertices
     num_vertices = 0
     read_number_of_vertices : do !define a do loop name
-       read(unit=10, fmt="(a)", iostat=ierror) string 
+       read(unit=10, fmt="(a)", iostat=ierror) string
        if(ierror<0) exit !ierror<0 means end of file
        if(index(string, "element vertex")> 0) then !keyword is found
           iend = len(string) !get the length of the string
@@ -1207,11 +1207,11 @@ contains
           exit
        endif
     end do read_number_of_vertices
-    
+
     !.....get the total number of triangles
     num_triangles = 0
     read_number_of_triangles : do !define a do loop name
-       read(unit=10, fmt="(a)", iostat=ierror) string 
+       read(unit=10, fmt="(a)", iostat=ierror) string
        if(ierror<0) exit !ierror<0 means end of file
        if(index(string, "element face")> 0) then !keyword is found
           iend = len(string) !get the length of the string
@@ -1235,19 +1235,19 @@ contains
        read(unit=10, fmt=*) i,triangle(1,nt),triangle(2,nt),triangle(3,nt)
     enddo
     triangle = triangle + 1 ! offset all vertices by 1 because indexing starts from zero
-    
+
     close(10)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine import_ply_triangles
 
 !!!#############################################################################
 
   subroutine triangles_from_surface(surface_elems)
     !*triangles_from_surface:* generates a linear surface mesh of triangles
-    ! from an existing high order surface mesh. 
-    
+    ! from an existing high order surface mesh.
+
     integer,intent(in) :: surface_elems(:)
     ! Local variables
     integer,parameter :: ndiv = 4 ! the number of triangle divisions in each direction
@@ -1257,7 +1257,7 @@ contains
     logical :: four_nodes
     character(len=3) :: repeat
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
 
     sub_name = 'triangles_from_surface'
@@ -1273,7 +1273,7 @@ contains
     num_surfaces = count(surface_elems.ne.0)
     num_triangles = 0
     num_vertices = 0
-    num_tri_vert = 0 
+    num_tri_vert = 0
 
     do nelem = 1,num_surfaces
        ne = surface_elems(nelem)
@@ -1286,7 +1286,7 @@ contains
 
        select case(repeat)
        case ('0_0')
-        
+
           nmax_1 = ndiv+1 ! ndiv+1 vertices in xi1 direction
           step_1 = 0      ! # of vertices in xi1 is constant
           nmax_2 = ndiv+1 ! ndiv+1 vertices in xi2 direction
@@ -1294,36 +1294,36 @@ contains
           index1 = 1
           index2 = 2
           four_nodes = .true.
-          
+
        case ('1_0')
-          
+
           nmax_1 = 1      ! start with 1 vertex in xi1 direction
           step_1 = 1      ! increase # of vertices in xi1 with each step in xi2
           nmax_2 = ndiv+1 ! ndiv+1 vertices in xi2 direction
           step_2 = 0      ! # of vertices in xi2 is constant
           index1 = 1
           index2 = 2
-          
+
        case ('1_1')
-          
+
           nmax_1 = ndiv+1 ! start with ndiv+1 vertices in xi1 direction
           step_1 = -1     ! decrease # of vertices in xi1 with each step in xi2
           nmax_2 = ndiv+1 ! ndiv+1 vertices in xi2 direction
           step_2 = 0      ! # of vertices in xi2 is constant
           index1 = 1
           index2 = 2
-          
+
        case ('2_0')
-          
+
           nmax_2 = ndiv+1 ! ndiv+1 vertices in xi1 direction
           step_2 = 0      ! # of vertices in xi1 is constant
           nmax_1 = 1      ! start with 1 vertex in xi2 direction
-          step_1 = 1      ! increase # of vertices in xi2 with each step in xi1          
+          step_1 = 1      ! increase # of vertices in xi2 with each step in xi1
           index2 = 1
           index1 = 2
-          
+
        case ('2_1')
-          
+
           nmax_2 = ndiv+1 ! ndiv+1 vertices in xi1 direction
           step_2 = 0      ! # of vertices in xi1 is constant
           nmax_1 = ndiv+1 ! start with ndiv+1 vertices in xi2 direction
@@ -1369,9 +1369,9 @@ contains
           nmax_1 = nmax_1 + step_1
        enddo !i
     enddo
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine triangles_from_surface
 
 !!!#############################################################################
@@ -1381,29 +1381,29 @@ contains
     !  a given parent element (ne_parent)
 
     use mesh_utilities,only: group_elem_by_parent
-    
+
     integer :: parent_list(:) ! will contain terminal elements below ne_parent on exit
     integer,intent(in) :: ne_parent  ! the parent element number
     ! Local Variables
     integer :: ne,ne_count,noelem,num_parents
     integer,allocatable :: templist(:)
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
 
     sub_name = 'group_elem_parent_term'
     call enter_exit(sub_name,1)
-    
+
     allocate(templist(num_elems))
     !if(.not.allocated(parentlist)) allocate(parentlist(num_elems))
-    
+
     ! get the list of elements that are subtended by ne_parent
     call group_elem_by_parent(ne_parent,templist)
-    
+
     ne_count = count(templist.ne.0) ! number of subtended elements
     num_parents = 0
 !    parentlist=0
-    
+
     do noelem = 1,ne_count
        ne = templist(noelem)
        if(elem_cnct(1,0,ne).eq.0)then
@@ -1411,19 +1411,19 @@ contains
           parent_list(num_parents)=ne
        endif !elem_cnct
     enddo !noelem
-    
+
     deallocate(templist)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine group_elem_parent_term
-  
+
 !!!#############################################################################
-  
+
   subroutine make_data_grid(surface_elems, num_target, offset, spacing0)
     !*make_data_grid:* makes a regularly-spaced 3D grid of data points to
     ! fill a bounding surface. surface is defined by elements in 'surface_elems'.
-    ! If zero then grow into all elements. 
+    ! If zero then grow into all elements.
 
     integer,intent(in) :: num_target, surface_elems(:)
     real(dp),intent(in) :: offset, spacing0
@@ -1433,9 +1433,9 @@ contains
     real(dp) :: cofm1(3),cofm2(3),boxrange(3),data_err,max_bound(3),min_bound(3), &
          scale_mesh,spacing,spacing_scale,volume
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'make_data_grid'
     call enter_exit(sub_name,1)
 
@@ -1465,7 +1465,7 @@ contains
     endif
 
 !!! find the bounding coordinates for the surface mesh
-    
+
     min_bound = minval(vertex_xyz,2)
     max_bound = maxval(vertex_xyz,2)
     boxrange = max_bound - min_bound
@@ -1494,35 +1494,35 @@ contains
        call make_grid(num_data,num_data_estimate,max_bound,min_bound,spacing)
     endif
     write(*,'('' Made'',I7,'' data points inside volume '',f6.1,'' mL'')') num_data,volume/1.0e3_dp
-        
+
     if(allocated(data_weight)) deallocate(data_weight)
     allocate(data_weight(3,num_data))
     data_weight(:,1:num_data) = 1.0_dp
 
     if(allocated(elem_list)) deallocate(elem_list)
-   
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine make_data_grid
-  
+
 !!!#############################################################################
 
   subroutine make_grid(num_data,num_data_estimate,max_bound,min_bound,spacing)
 
     use mesh_utilities,only: distance_between_points
-    
+
     integer :: num_data_estimate
     integer :: num_data
-    real(dp),intent(in) :: spacing 
+    real(dp),intent(in) :: spacing
     ! Local Variables
     integer :: i,j,k,nd,num_data_temp
     real(dp) :: dist,max_bound(3),min_bound(3),min_dist,point_xyz(3)
     real(dp),allocatable :: data_temp(:,:)
     logical :: internal
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'make_grid'
     call enter_exit(sub_name,1)
 
@@ -1534,7 +1534,7 @@ contains
     point_xyz = min_bound + 0.5_dp*spacing
     do while(point_xyz(3).le.max_bound(3)) ! for z direction
        i=i+1
-       j=0 
+       j=0
        do while(point_xyz(2).le.max_bound(2)) ! for y direction
           j=j+1
           k=0
@@ -1555,7 +1555,7 @@ contains
                    allocate(data_xyz(3,num_data_estimate))
                    data_xyz(:,1:num_data-1) = data_temp(:,1:num_data-1)
                    deallocate(data_temp) !deallocate the temporary array
-                   
+
                    write(*,'('' WARNING: number of data is'',I6, &
                         &''; increased array size'')') num_data
                    data_xyz(:,num_data) = point_xyz
@@ -1572,18 +1572,18 @@ contains
        point_xyz(1:2) = min_bound(1:2) + 0.5_dp*spacing
        point_xyz(3) = point_xyz(3) + spacing
     enddo
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine make_grid
-  
+
 !!!#############################################################################
-  
+
   subroutine make_2d_vessel_from_1d(elem_list)
     !*make_2d_vessel_from_1d:* create a surface mesh that aligns with the
     ! centrelines of a 1D tree, and located at distance 'radius' from the centre.
     ! a template for a set of 5 nodes (that together define a bifurcation) is
-    ! scaled, rotated, translated to align with the 1d mesh and its radii. 
+    ! scaled, rotated, translated to align with the 1d mesh and its radii.
 
     integer,intent(in) :: elem_list(:)
     ! Local variables
@@ -1606,7 +1606,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'make_2d_vessel_from_1d'
     call enter_exit(sub_name,1)
 
@@ -1632,7 +1632,7 @@ contains
     ne_new = 0  ! initialise the surface mesh element numbering
     np_new = 0  ! initialise the surface mesh node numbering
 
-!!! set up a generic structure (in template_coords) that will be rotated, scaled, and placed 
+!!! set up a generic structure (in template_coords) that will be rotated, scaled, and placed
     ! the following arrays define the template bifurcation
     template_vrsns = (/2,6,2,6,2/)
     template_vrsn_map = reshape((/1,2,3,1,1,3,2,1,1,5,4,2,2,4,5,1/),shape(template_vrsn_map))
@@ -1659,18 +1659,18 @@ contains
        node_xyz_2d(:,1,:,np_new) = new_coords_derivs(:,1,:,i) ! coordinates and derivatives 1,2,1_2
     enddo !i
     elem_node_map(1,5,np1) = elem_node_map(1,1,np1) !dummy (5th) node to help with mapping
-    
+
 !!! work through each of the elements in the given list, creating a ring of new
 !!! nodes and joining them to the previous ring of nodes. The assumption is that
 !!! the elements comprise a continuous tree
 
     ne_count = 1 ! counter for the 1d elements in the list
     do while (ne /= 0)
-       
+
        ne0 = elem_cnct(-1,1,ne) ! parent 1d element
-       np1 = elem_nodes(1,ne)   ! start node of current element 
+       np1 = elem_nodes(1,ne)   ! start node of current element
        np2 = elem_nodes(2,ne)   ! end node of current element
-       
+
        radius = elem_field(ne_radius,ne)
        length = elem_field(ne_length,ne)  ! length of current element
        if(.not.bifurcation_element(ne).and.bifurcation_element(ne0)) &
@@ -1681,7 +1681,7 @@ contains
           forall (k = 1:4) short_elements(num_short + k) = ne_new + k
           num_short = num_short + 4
        endif
-       
+
        ! calculate the rotation angle, translation (Txyz), and rotation matrices (Rx, Ry)
        call mesh_rotate_about_axis(ne,angle,Rx,Ry,Txyz,template_coords)
 
@@ -1691,7 +1691,7 @@ contains
           ! which 'ring' of parent nodes to join to when making new elements
           nvb = which_child(ne,ne0)  ! the 2nd child branch
        endif
-       
+
        if(.not.bifurcation_element(ne))then
 !!!    ---- for a single element that is the parent of a single element:
           ! make 4 new nodes using 'new_coords_derivs' at the end of the 1d element
@@ -1700,15 +1700,15 @@ contains
           radius_weighted = 0.0_dp
           call mesh_rotate_vector_about_axis(4,template_vrsns,angle,length,radius, &
                radius_weighted,Rx,Ry,Txyz,template_coords,new_coords_derivs)
-       
+
           ! as each new point is placed, check whether it is the closest to the first
           ! surface mesh node in ring of nodes surrounding the element, i.e. around
           ! node np1. This is used to determine the node numbering in the new element.
           smallest = 1.0e+6_dp
-          point1(:) = node_xyz_2d(1,1,:,elem_node_map(nvb,1,np1)) 
+          point1(:) = node_xyz_2d(1,1,:,elem_node_map(nvb,1,np1))
           do i = 1,4 ! four nodes in the end 'ring'
              np_new = np_new + 1
-             nodes_2d(np_new) = np_new 
+             nodes_2d(np_new) = np_new
              node_xyz_2d(:,1,:,np_new) = new_coords_derivs(:,1,:,i) ! coordinates and derivatives 1,2,1_2
              point2(:) = node_xyz_2d(1,1,:,np_new)
              distance = distance_between_points(point1,point2)
@@ -1731,27 +1731,27 @@ contains
                 elem_node_map(1,j,np2) = np_close(1)+j-1
              endif
           enddo ! j = 2,4
-          
+
           ! make new elements, using the node mapping stored in elem_node_map.
           ! nodes 1 and 2 use mapping stored at 1d node np1, and nodes 3 and 4
-          ! use mapping stored at 1d node np2. if the underlying 1d element is 
+          ! use mapping stored at 1d node np2. if the underlying 1d element is
           ! a child branch in a bifurcation then we need to get the correct
           ! version numbers (for derivatives) from template_vrsn_map.
           do i = 1,4  ! 4 new elements
              ne_new = ne_new + 1
-             elems_2d(ne_new) = ne_new  
+             elems_2d(ne_new) = ne_new
              forall(nn = 1:2) elem_nodes_2d(nn,ne_new) = elem_node_map(nvb,nn+i-1,np1)
              forall(nn = 3:4) elem_nodes_2d(nn,ne_new) = elem_node_map(1,i+nn-3,np2)
-             if(bifurcation_element(ne0)) & 
+             if(bifurcation_element(ne0)) &
                 forall(nn = 1:2) elem_versn_2d(nn,ne_new) = template_vrsn_map(nn,i+(nvb-1)*4)
           enddo ! i = 1,4
           forall (i=1:4) elem_node_map(1,i,np2) = np_new-4+i
           elem_node_map(1,5,np2) = elem_node_map(1,1,np2)
-          
+
        else if(bifurcation_element(ne)) then
 !!!    ---- for an element that is the parent of a bifurcation:
           ! create surface mesh nodes around the 1d element end node and at the crux.
-          
+
           ! Apply rotation and translation to each new node from the generic template
           radius_weighted = 0.5_dp*radius+0.5_dp*max(elem_field(ne_radius,elem_cnct(1,1,ne)), &
                elem_field(ne_radius,elem_cnct(1,2,ne))) ! average of branch and largest child
@@ -1759,15 +1759,15 @@ contains
                radius_weighted,Rx,Ry,Txyz,template_coords,new_coords_derivs)
           new_coords_derivs(3,1,:,1) = new_coords_derivs(3,2,:,1)
           new_coords_derivs(3,1,:,3) = new_coords_derivs(3,2,:,3)
-          
+
           ! adjust location of crux node using the location of the end node of
           ! the underlying 1d element, and end nodes of two child elements
           call mesh_2d_from_1d_crux(elem_nodes(2,ne),elem_cnct(1,1,ne), &
                elem_cnct(1,2,ne),cruxdist,new_coords_derivs)
-          
+
           do i = 1,5  ! five nodes in the bifurcation
              np_new = np_new+1
-             nodes_2d(np_new) = np_new 
+             nodes_2d(np_new) = np_new
              elem_node_map(2,i,np2) = np_new ! record nodes in ring around np2
              node_versn_2d(np_new) = template_vrsns(i)
              ring_coords(:,i) = new_coords_derivs(1,1,:,i)  ! store the coords for 'ring'
@@ -1805,7 +1805,7 @@ contains
                 elem_node_map(nvb,j,np1) = np_close(1)+j-1
              endif
           enddo !j
-          
+
           ! create new surface elements joining the np1 and np2 rings
           do i = 1,4
              ne_new = ne_new+1
@@ -1816,13 +1816,13 @@ contains
           enddo ! i
           elem_nodes_2d(2,ne_new) = elem_node_map(nvb,1,np1)
           elem_nodes_2d(4,ne_new) = np_new-4
-          
+
           elem_node_map(1,1,np2) = np_new
           elem_node_map(2,3,np2) = np_new
           elem_node_map(1:2,5,np2) = elem_node_map(1:2,1,np2)
 
           np_crux = np_new
-          
+
           ! for an element that is the parent of a bifurcation, also create
           ! nodes and elements along each of the two child branches
           np0 = np1  ! the start node of the parent element
@@ -1833,21 +1833,21 @@ contains
              length = max(cruxdist*1.25_dp, 0.5_dp*(cruxdist*1.25_dp+ &
                   (elem_field(ne_length,ne_child) - radius*0.5_dp)))
              ring_distance(ne_child) = length
-             
+
              ! calculate the rotation angle for the branch
              call mesh_rotate_about_axis(ne_child,angle,Rx,Ry,Txyz,template_coords)
-             
+
              radius = elem_field(ne_radius,ne_child)
              radius_weighted = radius
              call mesh_rotate_vector_about_axis(4,template_vrsns,angle,length,radius, &
                   radius_weighted,Rx,Ry,Txyz,template_coords,new_coords_derivs)
-             
+
              do i = 1,4  ! four nodes in the new 'ring'
                 np_new = np_new + 1
                 nodes_2d(np_new) = np_new ! store new node number
                 node_xyz_2d(:,1,:,np_new) = new_coords_derivs(:,1,:,i) ! coordinates and derivatives 1,2,1_2
              enddo ! i
-             
+
              ! the bifurcation offers two potential rings of nodes to attach to.
              ! determine which is the correct ring using the angle between the
              ! direction of the child element and the direction from the start
@@ -1867,7 +1867,7 @@ contains
 
              nvb = 1
              if(angle.gt.angle_btwn_points(point1,point2,point3)) nvb = 2
-             
+
              ! determine which of the nodes in the bifurcation ring the new nodes
              ! should attach to based on which of the new nodes is the closest to
              ! the 5th (for nvb=1) or 1st (for nvb=2) ring node
@@ -1884,7 +1884,7 @@ contains
                    np_close(nvb) = np_new + j
                 endif
              enddo !i
-             
+
              ! record the node mapping in the ring
              elem_node_map(k,1,np1) = np_close(nvb)
              elem_node_map(k,5,np1) = elem_node_map(k,1,np1)
@@ -1909,9 +1909,9 @@ contains
                 forall(nn = 3:4) elem_nodes_2d(nn,ne_new) = elem_node_map(k,i+nn-3,np1)
              enddo !i
           enddo !k
-          
+
        endif ! .not.bifurcation(ne)
-       
+
        ne_count = ne_count+1
        if(ne_count.gt.num_elems)then
           ne = 0
@@ -1924,7 +1924,7 @@ contains
           endif
        endif
     enddo ! while (ne /= 0)
-    
+
     num_nodes_2d = np_new
     num_elems_2d = ne_new
 
@@ -1941,9 +1941,9 @@ contains
     deallocate(elem_node_map)
     deallocate(ring_distance)
     deallocate(short_elements)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine make_2d_vessel_from_1d
 
 !!!#############################################################################
@@ -1959,13 +1959,13 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'mesh_2d_from_1d_generic'
     call enter_exit(sub_name,1)
-      
+
     template_coords = 0.0_dp
 
-    !.....Set up a default ring of nodes. 
+    !.....Set up a default ring of nodes.
     do i = 1,4 ! step around the ring of nodes in four steps
        angle = 2.0_dp * pi * dble(i-1)/4.0_dp !=2*PI*step/number_of_steps
        !.......Derivatives
@@ -1992,7 +1992,7 @@ contains
     template_coords(3,2:5,2,2) = 0.0_dp
     template_coords(3,2:5,3,2)= 0.33_dp
     template_coords(3,4:5,1,2)= 0.33_dp
-    
+
     !.....Second side node
     template_coords(1,:,3,3) = -1.5_dp   ! side node
     template_coords(3,2,1,3) = -0.15_dp
@@ -2006,14 +2006,14 @@ contains
     template_coords(3,2:5,2,4) = 0.0_dp
     template_coords(3,2:5,3,4)= 0.33_dp
     template_coords(3,4:5,1,4)= 0.33_dp
-    
+
     !.....Crux node
     template_coords(1,:,3,5) = 1.5_dp
     template_coords(2,1,2,5) = 1.0_dp
     template_coords(2,2,:,5) = -template_coords(2,1,:,5)
     template_coords(3,1,1,5) = -0.3_dp
     template_coords(3,2,1,5) = 0.3_dp
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine mesh_2d_from_1d_generic
@@ -2024,7 +2024,7 @@ contains
     !*mesh_rotate_about_axis:* calculates the rotation matrices and z-angle for
     ! rotation of a vector about an arbitrary axis defined by the direction
     ! of element ne.
-    
+
     integer,intent(in) :: ne
     real(dp) :: angle_z,Rx(:,:),Ry(:,:),Txyz(:)
     real(dp),intent(in) :: template_coords(:,:,:,:)
@@ -2035,13 +2035,13 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'mesh_rotate_about_axis'
     call enter_exit(sub_name,1)
-      
+
     np1 = elem_nodes(1,ne)
     np2 = elem_nodes(2,ne)
-    
+
     ! Find next bifurcation nodes, for calculating rotation about the z-axis
     if(elem_cnct(1,0,ne).ge.2)then !get adjacent nodes
        np0 = np1
@@ -2066,7 +2066,7 @@ contains
        enddo
     endif
 
-!!! .....Calculate the rotation and translation matrices      
+!!! .....Calculate the rotation and translation matrices
 
 !!! np1 == start node, np2 == end node, np3 == end of child 1, np4 == end of child 2
 
@@ -2078,7 +2078,7 @@ contains
 !!!                             | 0 b/d  c/d |            | a 0  d |        |   0        0    |
 !!! where U(a,b,c) == branch direction (elem_direction(1:3,ne)) and d = sqrt(b2 + c2)
 !!! see www.paulbourke.net/geometry/rotate for explanation
-    
+
     Rx = 0.0_dp
     Ry = 0.0_dp
     Rx(1,1) = 1.0_dp !x-x = 1
@@ -2088,13 +2088,13 @@ contains
     Rx(2,3) = elem_direction(2,ne)/ln_23
     Rx(3,2) = -Rx(2,3)
     Rx(3,3) = Rx(2,2)
-    
+
     Ry(2,2) = 1.0_dp !x-x = 1
     Ry(1,1) = ln_23
     Ry(1,3) = elem_direction(1,ne)
     Ry(3,1) = -Ry(1,3)
     Ry(3,3) = Ry(1,1)
-    
+
     !.....The angle for rotation about the z-axis is equal to the angle
     !.....between the normal to the plane containing bifurcation nodes and
     !.....the theta=0 direction
@@ -2122,7 +2122,7 @@ contains
        enddo !nj
        V = X2 !-Txyz(nj)
        V = unit_vector(V)   ! the direction of the vector rotated about x and y axes
-       
+
        angle_z = min(scalar_product_3(V,NML),1.0_dp)
        angle_z = max(scalar_product_3(V,NML),-1.0_dp)
 
@@ -2133,7 +2133,7 @@ contains
        else
           angle_z = acos(angle_z) ! angle between normal and 2nd (front) node
        endif
-       
+
        V(:) = template_coords(1,1,:,3)   ! direction to the 'side' node
        V = unit_vector(V)
        !.......Calculate location of V if rotation about x- and y- was applied
@@ -2158,18 +2158,18 @@ contains
     else
        angle_z = 0.0_dp
     endif
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine mesh_rotate_about_axis
-    
+
 !!!#############################################################################
 
   subroutine mesh_rotate_vector_about_axis(N,template_vrsns,angle,length, &
        radius,radius_weighted,Rx,Ry,Txyz,template_coords,new_coords_derivs)
     !*mesh_rotate_vector_about_axis:* rotates a vector (starting at (0,0,0))
     ! about an arbitrary axis. Rotation matrices are in Rx and Ry.
-    ! angle is the amount to rotate about z-axis. 
+    ! angle is the amount to rotate about z-axis.
 
     integer,intent(in) :: N,template_vrsns(:)
     real(dp),intent(in) :: angle,length,radius,radius_weighted,Rx(3,3), &
@@ -2181,12 +2181,12 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'mesh_rotate_vector_about_axis'
     call enter_exit(sub_name,1)
-      
+
     new_coords_derivs = 0.0_dp
-    
+
     do i = 1,N !each node in ring, plus crux if at bifurcation
        do nk = 1,4
           do nv = 1,template_vrsns(i)
@@ -2245,7 +2245,7 @@ contains
     enddo !i
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine mesh_rotate_vector_about_axis
 
 !!!#############################################################################
@@ -2253,7 +2253,7 @@ contains
   subroutine mesh_2d_from_1d_crux(np0,ne_1,ne_2,distance,new_coords_derivs)
     !*mesh_2d_from_1d_crux:* adjusts the location of the crux node for deriving
     ! a 2d surface mesh over a 1d tree mesh.
-    
+
     integer,intent(in) :: ne_1,ne_2,np0
     real(dp) :: distance,new_coords_derivs(:,:,:,:)
     ! Local variables
@@ -2262,10 +2262,10 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'mesh_2d_from_1d_crux'
     call enter_exit(sub_name,1)
-      
+
     !adjust location of crux node
     radius_U = elem_field(ne_radius,ne_1)
     radius_V = elem_field(ne_radius,ne_2)
@@ -2291,7 +2291,7 @@ contains
 !!!..... n.w = 0
 !!!..... u.w = cos(angle_u) * Lw
 !!!..... v.w = cos(angle_v) * Lw
-      
+
     matrix(1,:) = N(:)
     matrix(2,:) = elem_direction(:,ne_1)
     matrix(3,:) = elem_direction(:,ne_2)
@@ -2314,12 +2314,12 @@ contains
     else
        weight = 0.75_dp
     endif
-    
+
     new_coords_derivs(1,1,1:3,5) = node_xyz(1:3,np0) + W(1:3) * distance * weight
     new_coords_derivs(1,2,:,5) = new_coords_derivs(1,1,:,5)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine mesh_2d_from_1d_crux
 
 !!!###########################################################################
@@ -2334,7 +2334,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'merge_2d_from_1d_mesh'
     call enter_exit(sub_name,1)
 
@@ -2371,7 +2371,7 @@ contains
           ne = ne + 4 ! skip to next ring
        endif
     enddo
-    
+
     non_zero = 0
     do np = 1,num_nodes_2d
        if(nodes_2d(np).ne.0)then
@@ -2379,7 +2379,7 @@ contains
        endif
     enddo
     num_nodes_2d = non_zero
-    
+
     non_zero = 0
     do ne = 1,num_elems_2d
        if(elems_2d(ne).ne.0)then
@@ -2406,7 +2406,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'merge_trifurcations'
     call enter_exit(sub_name,1)
 
@@ -2416,8 +2416,8 @@ contains
     ! for each of the 'short' surface elements, delete them by joining the
     ! parent and child elements together. Work on a group of 4 elements at
     ! a time, where the four elements run in the Xi1 direction == a ring
-    ! of elements in a cylinder . 
-    
+    ! of elements in a cylinder .
+
     do while (ne /= 0)
        ne_parent = elem_cnct_2d(-2,1,ne)  ! element proximal to the current one
        ne_child = elem_cnct_2d(2,1,ne)    ! element distal to the current one
@@ -2436,7 +2436,7 @@ contains
        elem_nodes_2d(3,ne_parent) = elem_nodes_2d(3,ne)
        elem_versn_2d(3,ne_parent) = elem_versn_2d(3,ne)
        elems_2d(ne) = 0
-       
+
        k = k + 1
        ne = short_elements(k)
        ne_parent = elem_cnct_2d(-2,1,ne)
@@ -2490,19 +2490,19 @@ contains
        k = k + 1
        ne = short_elements(k)
     enddo
-    
+
     num_nodes_2d = count(nodes_2d.ne.0)
     num_elems_2d = count(elems_2d.ne.0)
-       
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine merge_trifurcations
 
 !!!#############################################################################
 
   subroutine define_rad_from_file(FIELDFILE, radius_type_in)
-    !*define_rad_from_file:* reads in a radius field associated with an 
-    ! airway tree and assigns radius information to each element, also 
+    !*define_rad_from_file:* reads in a radius field associated with an
+    ! airway tree and assigns radius information to each element, also
     ! calculates volume of each element
 
     character(len=MAX_FILENAME_LEN), intent(in) :: FIELDFILE
@@ -2518,23 +2518,23 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_rad_from_file'
     call enter_exit(sub_name,1)
-    
+
     versions = .TRUE.
     if(present(radius_type_in))then
        radius_type = radius_type_in
     else
        radius_type = 'no_taper'
     endif
-    
+
     if(index(FIELDFILE, ".ipfiel")> 0) then !full filename is given
        readfile = FIELDFILE(1:250)
     else ! need to append the correct filename extension
        readfile = trim(FIELDFILE)//'.ipfiel'
     endif
-    
+
     open(10, file=readfile, status='old')
 
 !!! check whether reading in a node-based or element-based field
@@ -2561,7 +2561,7 @@ contains
              exit read_versions !exit the named do loop
           endif
        end do read_versions
-       
+
        np = 0
        !.....read the coordinate, derivative, and version information for each node.
        read_a_node : do !define a do loop name
@@ -2622,7 +2622,7 @@ contains
 
        ne = 0
        ne_counter = 0
-       
+
        read_an_elem : do !define a do loop name
           !.......read element number
           read(unit=10, fmt="(a)", iostat=ierror) ctemp1
@@ -2648,7 +2648,7 @@ contains
        end do read_an_elem
 
     endif
-    
+
 !!! Calculate element volume
     do ne = 1,num_elems
        if(radius_type.eq.'taper')then
@@ -2668,7 +2668,7 @@ contains
     enddo
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine define_rad_from_file
 
 !!!#############################################################################
@@ -2696,7 +2696,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'define_rad_from_geom'
     call enter_exit(sub_name,1)
 
@@ -2729,7 +2729,7 @@ contains
     else!element number defined
        read (START_FROM,'(I10)') ne_start
     endif
-    
+
     ne=ne_start
 
     if(ORDER_SYSTEM(1:3).eq.'fit')then
@@ -2758,7 +2758,7 @@ contains
              enddo
           endif
        enddo
-    
+
     else
 
        !Strahler and Horsfield ordering system
@@ -2787,11 +2787,11 @@ contains
     endif
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine define_rad_from_geom
 
 !!!#############################################################################
-  
+
   subroutine element_connectivity_1d()
     !*element_connectivity_1d:*  Calculates element connectivity in 1D and
     ! stores in array elem_cnct
@@ -2802,15 +2802,15 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'element_connectivity_1d'
     call enter_exit(sub_name,1)
-    
+
     elem_cnct = 0 !initialise
 
     ! calculate elems_at_node array: stores the elements that nodes are in
     elems_at_node(1:num_nodes,0) = 0 !initialise number of adjacent elements
-    
+
     do ne=1,num_elems
        do nn=1,2
           np=elem_nodes(nn,ne)
@@ -2818,11 +2818,11 @@ contains
           elems_at_node(np,elems_at_node(np,0))=ne ! local element that np is in
        enddo !nn
     enddo !noelem
-    
+
     ! calculate elem_cnct array: stores the connectivity of all elements
-    
+
     elem_cnct=0 !initialise all elem_cnct
-    
+
     do ne=1,num_elems
        !     ne_global=elems(noelem)
        if(NNT == 2) THEN !1d
@@ -2839,13 +2839,13 @@ contains
           enddo !noelem2
        endif
     enddo
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine element_connectivity_1d
 
 !!!#############################################################################
-  
+
   subroutine element_connectivity_2d
     !*element_connectivity_2d:*  Calculates element connectivity in 2D and
     ! stores in array elem_cnct_2d
@@ -2856,21 +2856,21 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'element_connectivity_2d'
     call enter_exit(sub_name,1)
-    
+
     if(allocated(elems_at_node_2d))then
        deallocate(elem_cnct_2d)
        deallocate(elems_at_node_2d)
     endif
     allocate(elem_cnct_2d(-2:2,0:10,num_elems_2d))
     allocate(elems_at_node_2d(num_nodes_2d,0:10))
-    
+
 !!! calculate elems_at_node_2d array: stores the elements that nodes are in
-    
+
     elems_at_node_2d = 0 !initialise all
-    
+
     do ne = 1,num_elems_2d
        do nn = 1,num_elem_nodes
           np = elem_nodes_2d(nn,ne)
@@ -2878,11 +2878,11 @@ contains
           elems_at_node_2d(np,elems_at_node_2d(np,0)) = ne !element that np is in
        enddo !nn
     enddo !noelem
-    
+
 !!! calculate elem_cnct_2d array: stores the connectivity of all elements
-    
+
     elem_cnct_2d = 0 !initialise all elem_cnct_2d
-    
+
     do ne = 1,num_elems_2d ! for each of the 2d elements
        np_list(1:4) = elem_nodes_2d(1:4,ne) ! the list of nodes in the element (including repeated)
 !!! check the elements attached to the 1st node
@@ -2893,13 +2893,13 @@ contains
              if(np_list(2).ne.np_list(1))then ! only if first two nodes are not repeated
                 if(inlist(np_list(2),np_list_2))then
                    elem_cnct_2d(-2,0,ne) = elem_cnct_2d(-2,0,ne)+1
-                   elem_cnct_2d(-2,elem_cnct_2d(-2,0,ne),ne) = ne2 
+                   elem_cnct_2d(-2,elem_cnct_2d(-2,0,ne),ne) = ne2
                 endif
              endif
              if(np_list(3).ne.np_list(1))then ! only if the two nodes are not repeated
                 if(inlist(np_list(3),np_list_2))then
                    elem_cnct_2d(-1,0,ne) = elem_cnct_2d(-1,0,ne)+1
-                   elem_cnct_2d(-1,elem_cnct_2d(-1,0,ne),ne) = ne2 
+                   elem_cnct_2d(-1,elem_cnct_2d(-1,0,ne),ne) = ne2
                 endif
              endif
           endif
@@ -2912,28 +2912,28 @@ contains
              if(np_list(2).ne.np_list(4))then ! only if two nodes are not repeated
                 if(inlist(np_list(2),np_list_2))then
                    elem_cnct_2d(1,0,ne) = elem_cnct_2d(1,0,ne)+1
-                   elem_cnct_2d(1,elem_cnct_2d(1,0,ne),ne) = ne2 
+                   elem_cnct_2d(1,elem_cnct_2d(1,0,ne),ne) = ne2
                 endif
              endif
              if(np_list(3).ne.np_list(4))then ! only if the two nodes are not repeated
                 if(inlist(np_list(3),np_list_2))then
                    elem_cnct_2d(2,0,ne) = elem_cnct_2d(2,0,ne)+1
-                   elem_cnct_2d(2,elem_cnct_2d(2,0,ne),ne) = ne2 
+                   elem_cnct_2d(2,elem_cnct_2d(2,0,ne),ne) = ne2
                 endif
              endif
           endif
        enddo !noelem2
     enddo
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine element_connectivity_2d
 
 !!!#############################################################################
 
   subroutine line_segments_for_2d_mesh(sf_option)
     !*line_segments_for_2d_mesh:* set up the line segment arrays for a 2d mesh
-    
+
     character(len=4),intent(in) :: sf_option
     ! Local variables
     integer :: index_nodes(2,4),j,line_nodes(2),ne,ne_adjacent,ni1,nj, &
@@ -2941,26 +2941,26 @@ contains
     logical :: MAKE
     logical :: based_on_elems = .true., found_nl
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'line_segments_for_2d_mesh'
     call enter_exit(sub_name,1)
 
     nxi = [1,1,2,2]
     index_nodes = reshape([1,2,3,4,1,3,2,4],shape(index_nodes))
-    
+
     if(allocated(elem_lines_2d)) deallocate(elem_lines_2d)
     if(allocated(scale_factors_2d)) deallocate(scale_factors_2d)
     allocate(elem_lines_2d(4,num_elems_2d))
     allocate(scale_factors_2d(16,num_elems_2d))
-    
+
     elem_lines_2d = 0
     num_lines_2d = 4 * num_elems_2d
-    
+
     if(based_on_elems)then
        elem_lines_2d = 0
-       
+
        if(allocated(lines_2d)) deallocate(lines_2d)
        if(allocated(line_versn_2d)) deallocate(line_versn_2d)
        if(allocated(lines_in_elem)) deallocate(lines_in_elem)
@@ -2970,7 +2970,7 @@ contains
        allocate(line_versn_2d(2,3,num_lines_2d))
        allocate(lines_in_elem(0:4,num_lines_2d))
        allocate(nodes_in_line(3,0:3,num_lines_2d))
-       allocate(arclength(num_lines_2d)) 
+       allocate(arclength(num_lines_2d))
 
        lines_in_elem = 0
        lines_2d = 0
@@ -3003,7 +3003,7 @@ contains
                 lines_2d(num_lines_2d) = num_lines_2d !record a new line number
                 lines_in_elem(0,num_lines_2d) = lines_in_elem(0,num_lines_2d) + 1
                 lines_in_elem(lines_in_elem(0,num_lines_2d),num_lines_2d) = ne !line num_lines_2d is in element ne
-                elem_lines_2d(nline,ne) = num_lines_2d 
+                elem_lines_2d(nline,ne) = num_lines_2d
                 nodes_in_line(2,1,num_lines_2d) = np1
                 nodes_in_line(3,1,num_lines_2d) = np2
                 nodes_in_line(1,0,num_lines_2d) = nxi(nline)
@@ -3018,11 +3018,11 @@ contains
           enddo !nline
        enddo ! ne
     endif
-    
+
     call calc_scale_factors_2d(sf_option)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine line_segments_for_2d_mesh
 
 !!!#############################################################################
@@ -3036,14 +3036,14 @@ contains
          n_generation,n_horsfield,OUTLETS,STRAHLER,STRAHLER_ADD,temp1
     LOGICAL :: DISCONNECT,DUPLICATE,problem
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'evaluate_ordering'
     call enter_exit(sub_name,1)
 
     problem = .false.
-    
+
 !!! Calculate branch generations
     elem_ordrs = 0
     maxgen=1
@@ -3095,7 +3095,7 @@ contains
        elem_ordrs(2,ne)=n_horsfield !store the Horsfield order
        elem_ordrs(3,ne)=STRAHLER+STRAHLER_ADD !Strahler order
     enddo !noelem
-    
+
 !!! Check for disconnected nodes and number of inlets and outlets
     DUPLICATE=.FALSE.
     do ne=1,num_elems
@@ -3109,7 +3109,7 @@ contains
           read(*,*)
        endif
     enddo
-    
+
     DISCONNECT=.FALSE.
     INLETS=0
     OUTLETS=0
@@ -3166,7 +3166,7 @@ contains
     endif
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine evaluate_ordering
 
 !!!#############################################################################
@@ -3175,7 +3175,7 @@ contains
     !*set_initial_volume:* assigns a volume to terminal units appended on a
     ! tree structure based on an assumption of a linear gradient in the
     ! gravitational direction with max, min, and COV values defined.
-    
+
     integer,intent(in) :: Gdirn
     real(dp),intent(in) :: COV,total_volume,Rmax,Rmin
     !     Local parameters
@@ -3185,20 +3185,20 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'set_initial_volume'
     call enter_exit(sub_name,1)
-    
+
     volume_estimate = 1.0_dp
     volume_of_tree = 0.0_dp
-    
+
     call volume_of_mesh(volume_estimate,volume_of_tree)
-    
+
     random_number=-1.1_dp
-    
+
     Vmax = Rmax * (total_volume-volume_estimate)/elem_units_below(1)
     Vmin = Rmin * (total_volume-volume_estimate)/elem_units_below(1)
-    
+
 !!! for each elastic unit find the maximum and minimum coordinates in the Gdirn direction
     max_z=-1.0e+6_dp
     min_z=1.0e+6_dp
@@ -3208,10 +3208,10 @@ contains
        max_z=MAX(max_z,node_xyz(Gdirn,np2))
        min_z=MIN(min_z,node_xyz(Gdirn,np2))
     enddo !nunit
-    
+
     range_z=abs(max_z-min_z)
     if(abs(range_z).le.1.0e-5_dp) range_z=1.0_dp
-    
+
 !!! for each elastic unit allocate a size based on a gradient in the Gdirn direction, and
 !!! perturb by a user-defined COV. This should be calling a random number generator.
     do nunit=1,num_units
@@ -3223,20 +3223,20 @@ contains
        unit_field(nu_vol,nunit)=(Vmax*Xi+Vmin*(1.0_dp-Xi))*(1.0_dp+COV*random_number)
        unit_field(nu_vt,nunit)=0.0_dp !initialise the tidal volume to a unit
     enddo !nunit
-    
+
     ! correct unit volumes such that total volume is exactly as specified
     call volume_of_mesh(volume_estimate,volume_of_tree)
     factor_adjust = (total_volume-volume_of_tree)/(volume_estimate-volume_of_tree)
     do nunit=1,num_units
        unit_field(nu_vol,nunit) = unit_field(nu_vol,nunit)*factor_adjust
     enddo
-    
+
     write(*,'('' Number of elements is '',I5)') num_elems
     write(*,'('' Initial volume is '',F6.2,'' L'')') total_volume/1.0e+6_dp
     write(*,'('' Deadspace volume is '',F6.1,'' mL'')') volume_of_tree/1.0e+3_dp
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine set_initial_volume
 
 !!!#############################################################################
@@ -3244,7 +3244,7 @@ contains
   subroutine volume_of_mesh(volume_model,volume_tree)
     !*volume_of_mesh:* calculates the volume of an airway mesh including
     ! conducting and respiratory airways
-    
+
     real(dp) :: volume_model,volume_tree
     !     Local Variables
     integer :: ne,ne0,nunit
@@ -3255,10 +3255,10 @@ contains
 
     sub_name = 'volume_of_mesh'
     call enter_exit(sub_name,1)
-    
+
     if(.not.allocated(vol_anat)) allocate(vol_anat(num_elems))
     if(.not.allocated(vol_below)) allocate(vol_below(num_elems))
-    
+
     vol_anat = elem_field(ne_vol,1:num_elems) !initialise to branch volume
     vol_below = elem_field(ne_vol,1:num_elems) !initialise to branch volume
 
@@ -3282,16 +3282,16 @@ contains
 
     deallocate(vol_anat)
     deallocate(vol_below)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine volume_of_mesh
 
 !!!#############################################################################
 
   subroutine write_geo_file(type, filename)
     !*write_geo_file:* converts a surface mesh (created using make_2d_vessel_from_1d)
-    ! into a gmsh formatted mesh and writes to file. 
+    ! into a gmsh formatted mesh and writes to file.
     ! options on 'type': 1== single layered surface mesh of the vessel wall
     !                    2== double-layered thick-walled volume mesh of vessel wall
     !                    3== volume mesh of vessel lumen
@@ -3309,19 +3309,19 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'write_geo_file'
     call enter_exit(sub_name,1)
 
     opfile = trim(filename)//'.geo'
     open(10, file=opfile, status='replace')
-      
+
     write(ifile,'(''/***********************'')')
     write(ifile,'(''*'')')
     write(ifile,'(''* Conversion of LungSim to GMSH'')')
     write(ifile,'(''*'')')
     write(ifile,'(''***********************/'')')
-    
+
     write(ifile,'(/''lc ='',f8.4,'';'')') lc0
     write(ifile,'(/''sc ='',f8.4,'';'')') lc1
     write(ifile,'(/)')
@@ -3330,14 +3330,14 @@ contains
     allocate(elem_surfaces(5,num_elems_2d))
     element_spline = 0
     elem_surfaces = 0
-    ncount_spline = 0 
+    ncount_spline = 0
     np_offset = 0
 
     if(type.eq.1)then
 !!! write out a surface mesh that describes a structured vessel surface
        call write_surface_geo(element_spline,elem_surfaces,ifile,ncount_point, &
             ncount_loop,ncount_spline,np_offset)
-       
+
     else if(type.eq.2)then
 !!! write out a volume that encloses a thick-walled vessel tree. Make a gmsh .geo file
 !!! for the surface of the tree, then copy, scale, and translate to get an 'outer shell'.
@@ -3382,11 +3382,11 @@ contains
     close(ifile)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine write_geo_file
-  
+
 !!!#############################################################################
-  
+
   function get_final_real(string)
     !*get_final_real:* gets the last real number on a string
 
@@ -3395,9 +3395,9 @@ contains
     integer :: ibeg,iend
     real(dp) :: rsign,rtemp,get_final_real
     character :: sub_string*(40)
-    
+
     ! --------------------------------------------------------------------------
-    
+
     iend=len(string) !get the length of the string
     ibeg=index(string,":")+1 !get location of real in string
     sub_string = adjustl(string(ibeg:iend)) ! get the characters beyond :
@@ -3409,12 +3409,12 @@ contains
        rsign=1.0_dp
        ibeg=1
     endif
-   
+
     read (sub_string(ibeg:iend), * ) rtemp !get real value
     rtemp=rtemp*rsign !apply sign to number
-    
+
     get_final_real=rtemp !return the real value
-    
+
   end function get_final_real
 
 !!!#############################################################################
@@ -3432,10 +3432,10 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'get_final_string'
     call enter_exit(sub_name,1)
-    
+
     iend=len(string) !get the length of the string
     ibeg=index(string,":")+1 !get location of real in string
     sub_string = adjustl(string(ibeg:iend)) ! get the characters beyond :
@@ -3449,7 +3449,7 @@ contains
     endif
     read (sub_string(ibeg:iend), '(D25.17)' ) rtemp !get real value
     rtemp=rtemp*rsign !apply sign to number
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine get_final_string
@@ -3467,10 +3467,10 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'get_local_node'
     call enter_exit(sub_name,1)
-    
+
     np=1
     found=.false.
     do while (.not.found)
@@ -3484,13 +3484,13 @@ contains
           np=np+1
        endif
     enddo
-    
+
     np_local = np
 
     call enter_exit(sub_name,2)
 
   end subroutine get_local_node
-  
+
 !!!#############################################################################
 
   function get_parent_branch(ne)
@@ -3516,7 +3516,7 @@ contains
     endif
 
   end function get_parent_branch
-    
+
 !!!#############################################################################
 
   subroutine geo_entry_exit_cap(element_spline,ifile,ncount_loop, &
@@ -3529,13 +3529,13 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'geo_entry_exit_cap'
     call enter_exit(sub_name,1)
-        
+
     ne = 1
     do while (ne.le.num_elems_2d)
-       
+
        if(elem_cnct_2d(-2,0,ne).eq.0)then
           do k = 0,3
              np1 = elem_nodes_2d(1,ne+k)
@@ -3563,7 +3563,7 @@ contains
                   ncount_loop, ncount_loop - 1
           enddo
        endif
-       
+
        if(elem_cnct_2d(2,0,ne).eq.0)then
           do k = 0,3
              np1 = elem_nodes_2d(3,ne+k)
@@ -3591,32 +3591,32 @@ contains
                   ncount_loop, ncount_loop - 1
           enddo
        endif
-       
+
        ne = ne + 4
     enddo
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine geo_entry_exit_cap
 
 !!!#############################################################################
 
   subroutine geo_node_offset(node_xyz_offset)
-    
+
     real(dp) :: node_xyz_offset(:,:)
     ! Local variables
     integer:: j,k,ne,np1
     real(dp) :: point_temp(3),point_xyz_centre(3),wall_thickness
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'geo_node_offset'
     call enter_exit(sub_name,1)
-        
+
     ne = 1
     do while (ne.le.num_elems_2d)
-       
+
 !!!....nodes at model entry
        if(elem_cnct_2d(-2,0,ne).eq.0)then
           point_xyz_centre(:) = 0.0_dp
@@ -3632,10 +3632,10 @@ contains
              np1 = elem_nodes_2d(1,ne+k)
              point_temp(1:3) = node_xyz_2d(1,1,1:3,np1)
              node_xyz_offset(:,np1) = wall_thickness * &
-                  direction_point_to_point(point_xyz_centre,point_temp) 
+                  direction_point_to_point(point_xyz_centre,point_temp)
           enddo  ! k
        endif  ! elem_cnct
-       
+
 !!!....nodes at Xi2=1 ends of 'rings'
        point_xyz_centre(:) = 0.0_dp
        do k = 0,3
@@ -3663,15 +3663,15 @@ contains
        endif
 
        ne = ne + 4
-       
+
     enddo ! while (ne.le.num_elems_2d)
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine geo_node_offset
-  
+
 !!!#############################################################################
-  
+
   subroutine reallocate_node_elem_arrays(num_elems_new,num_nodes_new)
     !*reallocate_node_elem_arrays:* Reallocates the size of geometric
     ! arrays when modifying geometries
@@ -3689,34 +3689,34 @@ contains
 
     sub_name = 'reallocate_node_elem_arrays'
     call enter_exit(sub_name,1)
-    
+
     allocate(nodelem_temp(num_nodes))
     nodelem_temp = nodes ! copy to temporary array
     deallocate(nodes) !deallocate initially allocated memory
     allocate(nodes(num_nodes_new))
     nodes(1:num_nodes)=nodelem_temp(1:num_nodes)
     deallocate(nodelem_temp) !deallocate the temporary array
-    
+
     allocate(xyz_temp(3,num_nodes))
     xyz_temp=node_xyz
     deallocate(node_xyz)
     allocate(node_xyz(3,num_nodes_new))
     node_xyz(1:3,1:num_nodes)=xyz_temp(1:3,1:num_nodes)
-    
+
     allocate(nodelem_temp(num_elems))
     nodelem_temp = elems ! copy to temporary array
     deallocate(elems) !deallocate initially allocated memory
     allocate(elems(num_elems_new))
     elems(1:num_elems)=nodelem_temp(1:num_elems)
     deallocate(nodelem_temp) !deallocate the temporary array
-    
+
     allocate(enodes_temp(2,num_elems))
     enodes_temp=elem_nodes
     deallocate(elem_nodes)
     allocate(elem_nodes(2,num_elems_new))
     elem_nodes(1:2,1:num_elems)=enodes_temp(1:2,1:num_elems)
     deallocate(enodes_temp)
-    
+
     if(allocated(elem_field).and.num_ne.gt.0)then
        allocate(rnodes_temp(num_ne,num_elems))
        rnodes_temp=elem_field
@@ -3726,7 +3726,7 @@ contains
        deallocate(rnodes_temp)
        elem_field(1:num_ne,num_elems+1:num_elems_new) = 0.0_dp
     endif
-    
+
     allocate(rnodes_temp(3,num_elems))
     rnodes_temp=elem_direction
     deallocate(elem_direction)
@@ -3734,7 +3734,7 @@ contains
     elem_direction(1:3,1:num_elems)=rnodes_temp(1:3,1:num_elems)
     deallocate(rnodes_temp)
     elem_direction(1:3,num_elems+1:num_elems_new) = 0.0_dp
-    
+
     if(allocated(node_field).and.num_nj.gt.0)then
        allocate(rnodes_temp(num_nj,num_nodes))
        rnodes_temp=node_field
@@ -3744,7 +3744,7 @@ contains
        deallocate(rnodes_temp)
        node_field(1:num_nj,num_nodes+1:num_nodes_new)=0.0_dp
     endif
-    
+
     allocate(nodelem_temp(num_elems))
     nodelem_temp = elem_symmetry ! copy to temporary array
     deallocate(elem_symmetry) !deallocate initially allocated memory
@@ -3752,7 +3752,7 @@ contains
     elem_symmetry(1:num_elems)=nodelem_temp(1:num_elems)
     deallocate(nodelem_temp) !deallocate the temporary array
     elem_symmetry(num_elems+1:num_elems_new)=1
-    
+
     allocate(enodes_temp2(-1:1,0:2,0:num_elems))
     enodes_temp2=elem_cnct
     deallocate(elem_cnct)
@@ -3760,7 +3760,7 @@ contains
     elem_cnct(-1:1,0:2,0:num_elems)=enodes_temp2(-1:1,0:2,0:num_elems)
     deallocate(enodes_temp2)
     elem_cnct(-1:1,0:2,num_elems+1:num_elems_new) = 0
-    
+
     allocate(enodes_temp(num_ord,num_elems))
     enodes_temp=elem_ordrs
     deallocate(elem_ordrs)
@@ -3768,7 +3768,7 @@ contains
     elem_ordrs(1:num_ord,1:num_elems)=enodes_temp(1:num_ord,1:num_elems)
     deallocate(enodes_temp)
     elem_ordrs(1:num_ord,num_elems+1:num_elems_new) = 0
-    
+
     if(allocated(elem_units_below).and.num_nu.gt.0)then
        allocate(nodelem_temp(num_elems))
        nodelem_temp=elem_units_below
@@ -3778,7 +3778,7 @@ contains
        deallocate(nodelem_temp)
        elem_units_below(num_elems+1:num_elems_new)=0
     endif
-    
+
     allocate(enodes_temp(num_nodes,0:3))
     enodes_temp=elems_at_node
     deallocate(elems_at_node)
@@ -3786,7 +3786,7 @@ contains
     elems_at_node(1:num_nodes,0:3)=enodes_temp(1:num_nodes,0:3)
     deallocate(enodes_temp)
     elems_at_node(num_nodes+1:num_nodes_new,0:3)=0
-    
+
     if(model_type.eq.'gas_mix')then
        allocate(exp_temp(num_elems))
        exp_temp = expansile
@@ -3796,15 +3796,15 @@ contains
        deallocate(exp_temp)
        expansile(num_elems+1:num_elems_new)=.false.
     endif
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine reallocate_node_elem_arrays
-  
+
 !!!#############################################################################
-  
+
   function get_local_node_f(ndimension,np_global) result(get_local_node)
-    
+
     integer,intent(in) :: ndimension,np_global
     ! Local variables
     integer :: np
@@ -3815,9 +3815,9 @@ contains
 
     found = .false.
     np = 0
-    
+
     select case (ndimension)
-       
+
     case(1)
        do while (.not.found)
           np=np+1
@@ -3830,7 +3830,7 @@ contains
              found = .true.
           endif
        enddo
-       
+
     case(2)
        do while (.not.found)
           np=np+1
@@ -3844,24 +3844,24 @@ contains
              found = .true.
           endif
        enddo
-       
+
     end select
-    
+
   end function get_local_node_f
-  
+
 !!!#############################################################################
-  
+
   function get_final_integer(string)
     !*get_final_integer*
-    
+
     character,intent(in) :: string*(*)
     ! Local parameters
     integer :: ibeg,iend,ierror,nsign,ntemp
     character :: sub_string*(40)
     integer :: get_final_integer
-    
+
     ! --------------------------------------------------------------------------
-    
+
     iend=len(string) !get the length of the string
     ibeg=index(string,":")+1 !get location of integer in string, follows ":"
     sub_string = adjustl(string(ibeg:iend)) ! get the characters beyond ":"
@@ -3873,7 +3873,7 @@ contains
        nsign=1
        ibeg=1
     endif
-    
+
     read (sub_string(ibeg:iend), '(i10)', iostat=ierror ) ntemp !get integer values
     if(ierror.gt.0)then
        !... something wrong with data
@@ -3881,13 +3881,13 @@ contains
        write(*,'(a)') sub_string(ibeg:iend)
     endif
     ntemp=ntemp*nsign !apply sign to number
-    
+
     get_final_integer=ntemp !return the integer value
-    
+
   end function get_final_integer
-  
+
 !!!#############################################################################
-  
+
   subroutine get_four_nodes(ne,string)
 
     integer, intent(in) :: ne
@@ -3906,7 +3906,7 @@ contains
     ibeg=index(string,":")+1 !get location of first integer in string
     sub_string = adjustl(string(ibeg:iend)) ! get the characters beyond : and remove the leading blanks
     i_ss_end=len(sub_string) !get the end location of the sub-string
-    
+
     ibeg=1
     do nn=1,4
        iend=index(sub_string," ") !get location of first blank in sub-string
@@ -3916,9 +3916,9 @@ contains
     enddo ! nn
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine get_four_nodes
-  
+
 !!!#############################################################################
 
   subroutine redistribute_mesh_nodes_2d_from_1d
@@ -3931,7 +3931,7 @@ contains
     character(len=60) :: sub_name
 
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'redistribute_mesh_nodes_2d_from_1d'
     call enter_exit(sub_name,1)
 
@@ -3959,11 +3959,11 @@ contains
              point4(1:3) = node_xyz_2d(1,1,1:3,np)   ! the location of the crux node
              ! calculate the distance from the crux (point4) to the plane of first adjacent ring
              line_length = distance_from_plane_to_point(point1,point2,point3,point4)
-             
+
              point1(1:3) = node_xyz_2d(1,1,1:3,np-1)   ! the location of the 'back' node of bifurcation
 !!             ! calculate the line length from back node to a point on the first ring
 !!             distance_to_crux_last = distance_between_points(point1,point2)
-             
+
              continue = .true.
              do while(continue)   ! keep going: note that bifurcation will have > 1 version at nodes
                 if(elem_cnct_2d(2,0,ne).eq.0)then ! no adjacent 2d elements in Xi+2 direction
@@ -3985,16 +3985,16 @@ contains
                         node_xyz_2d(1,1,1:3,np_last)
                    vector = unit_vector(vector)
                    nedirection(1:3,num_list-1) = vector(1:3)  ! store the direction
-                   ! continue until the next bifurcation is detected (nodes with > 1 version)                   
+                   ! continue until the next bifurcation is detected (nodes with > 1 version)
                    if(node_versn_2d(np_adjacent).ne.1) continue = .false.
                 endif
              enddo
 
              line_length = line_length/real(num_list) ! this is the length to redistribute rings to
-             
+
 !!!          adjust the location of the nodes in each 'ring'
              do j = 1,num_list - 1   ! only adjust the rings that are between bifns: last 'ring' is actually the next bifn
-                
+
                 ! first get the list of nodes in the ring
                 ring1_nodes(1) = nplist(j)
                 ne_adjacent = elem_cnct_2d(1,1,nelist(j)) ! get the next element in the +Xi1 direction
@@ -4002,10 +4002,10 @@ contains
                    ring1_nodes(k) = elem_nodes_2d(4,ne_adjacent)
                    ne_adjacent = elem_cnct_2d(1,1,ne_adjacent) ! get the next element in the +Xi1 direction
                 enddo ! k
-                
+
                 ! assume that the direction for adjustment is defined by location of adjacent rings
                 vector(1:3) = nedirection(1:3,j)
-                
+
                 ! calculate the ring displacement = j*line_length - (distance from crux)
                 point1(1:3) = node_xyz_2d(1,1,1:3,ring1_nodes(1))
                 point2(1:3) = node_xyz_2d(1,1,1:3,ring1_nodes(2))
@@ -4013,7 +4013,7 @@ contains
                 point4(1:3) = node_xyz_2d(1,1,1:3,np)
                 displace_length = real(j) * line_length - &
                      distance_from_plane_to_point(point1,point2,point3,point4)
-                
+
                 ! update the location of the four nodes in the current ring
                 do k = 1,4
                    node_xyz_2d(1,1,1:3,ring1_nodes(k)) = &
@@ -4025,15 +4025,15 @@ contains
        endif
        np = np + 1 ! increment to check the next node
     enddo
-    
+
     call enter_exit(sub_name,2)
-    
+
   end subroutine redistribute_mesh_nodes_2d_from_1d
 
 !!!#############################################################################
-  
+
   function coord_at_xi(ne,xi,basis)
-    
+
     integer,intent(in) :: ne
     real(dp),intent(in) :: xi(:)
     character(len=*),intent(in) :: basis
@@ -4043,7 +4043,7 @@ contains
     real(dp) :: coord_at_xi(3)
 
     ! --------------------------------------------------------------------------
-    
+
     select case (basis)
     case('linear')
        forall (nn=1:4) x(1,1:3,nn) = node_xyz_2d(1,1,1:3,elem_nodes_2d(nn,ne))
@@ -4051,10 +4051,10 @@ contains
        phi(2) = xi(1)*(1.0_dp - xi(2))
        phi(3) = (1.0_dp - xi(1))*xi(2)
        phi(4) = xi(1)*xi(2)
-       
+
        coord_at_xi(1:3) = phi(1)*x(1,1:3,1)+phi(2)*x(1,1:3,2)+phi(3)* &
             x(1,1:3,3)+phi(4)*x(1,1:3,4)
-       
+
     case('hermite')
        do nn=1,4
           nv = elem_versn_2d(nn,ne)
@@ -4085,9 +4085,9 @@ contains
             + phi_11(1)*phi_21(2)*x(4,1:3,3) &
             + phi_21(1)*phi_21(2)*x(4,1:3,4)
     end select
-    
+
   end function coord_at_xi
-  
+
 !!!#############################################################################
 
   function get_local_elem(ne_global)
@@ -4127,7 +4127,7 @@ contains
 !!!#############################################################################
 
   function where_inlist(item,ilist)
-    
+
     integer :: item,ilist(:)
     integer :: n
     integer :: where_inlist
@@ -4135,9 +4135,9 @@ contains
     do n=1,size(ilist)
        if(item == ilist(n)) where_inlist = n
     enddo
-    
+
   end function where_inlist
-  
+
 !!!###########################################################################
 
   subroutine write_elem_geometry_2d(elemfile)
@@ -4147,7 +4147,7 @@ contains
     integer :: ne,ne_count,nglobal_list(4),np,nv
     character(len=132) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
 
     sub_name = 'write_elem_geometry_2d'
@@ -4155,7 +4155,7 @@ contains
 
     writefile = trim(elemfile)//'.ipelem'
     open(10, file=writefile, status='replace')
-    
+
     !.....write the total number of elems
     write(10,'('' CMISS Version 2.1  ipelem File Version 2'')')
     write(10,'('' Heading: 2D surface from 1D centreline'')')
@@ -4206,15 +4206,15 @@ contains
     integer :: i,np,np_count,nv
     character(len=132) :: writefile
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'write_node_geometry_2d'
     call enter_exit(sub_name,1)
 
     writefile = trim(nodefile)//'.ipnode'
     open(10, file=writefile, status='replace')
-    
+
     !.....write the total number of nodes
     write(10,'('' CMISS Version 1.21 ipnode File Version 2'')')
     write(10,'('' Heading: '')')
@@ -4240,8 +4240,8 @@ contains
           do i=1,3
              write(10,'('' The number of versions for nj='',i1,'' is [1]:'',i2)')  i,node_versn_2d(np)
              do nv=1,node_versn_2d(np)
-                if(node_versn_2d(np).gt.1) write(10,'('' For version number '',i1,'':'')') nv 
-                !...........coordinate          
+                if(node_versn_2d(np).gt.1) write(10,'('' For version number '',i1,'':'')') nv
+                !...........coordinate
                 write(10,'('' The Xj('',i1,'') coordinate is [ 0.00000E+00]: '',f12.5)') &
                      i,node_xyz_2d(1,nv,i,np)
                 write(10,'('' The derivative wrt direction 1 is [ 0.00000E+00]: '',f12.5)') &
@@ -4257,14 +4257,14 @@ contains
     close(10)
 
      call enter_exit(sub_name,2)
- 
+
   end subroutine write_node_geometry_2d
 
 !!!#############################################################################
 
   subroutine write_surface_geo(element_spline,elem_surfaces,ifile,ncount_point, &
        ncount_loop,ncount_spline,np_offset)
-    
+
     integer :: element_spline(:,:),elem_surfaces(:,:),ifile,ncount_point, &
          ncount_loop,ncount_spline,np_offset
     ! Local variables
@@ -4274,16 +4274,16 @@ contains
     real(dp) :: phi_1_0,phi_1_1,phi_2_0,phi_2_1,point_xyz(3),xidivn(3)
     logical :: repeat
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'write_surface_geo'
     call enter_exit(sub_name,1)
 
     allocate(crux_lines(num_elems,3))
-    
+
     forall (i=1:3) xidivn(i) = 0.25_dp * i
-    
+
 !!!    Make a gmsh 'point' at each of the surface mesh nodes
     write(ifile,'(''/* Points */'')')
     do np = 1,num_nodes_2d
@@ -4291,16 +4291,16 @@ contains
        write(ifile,'(''Point('',i8,'') = {'',f12.7,'','',f12.7,'','',f12.7,'',lc};'')') &
             ncount_point,node_xyz_2d(1,1,1:3,np)
     enddo
-    
+
 !!!    Now work through each 'ring' of four adjoining surface elements. Points are created
 !!!    between adjacent nodes in the Xi1 and Xi2 directions.
 
     element_spline = 0
     num_crux_lines = 0
     ne = 1
-    
+
     do while (ne.le.num_elems_2d)
-       
+
 !!!....make intermediate points, lines, surfaces, at Xi2=0 for model entry .........
        if((elem_cnct_2d(-2,0,ne).eq.0) .or. &
             (node_versn_2d(elem_nodes_2d(1,ne)).eq.6.or.&
@@ -4335,7 +4335,7 @@ contains
                               + phi_1_1 * node_xyz_2d(nk,nv1,j,np1) * scale_factors_2d(2,ne+k) &
                               + phi_2_1 * node_xyz_2d(nk,nv2,j,np2) * scale_factors_2d(6,ne+k)
                       enddo
-                      
+
                       ncount_point = ncount_point + 1
                       write(ifile,'(''Point('',i8,'') = {'',f12.7,'','',f12.7,'','',f12.7,'',lc};'')') &
                            ncount_point, point_xyz(1:3)
@@ -4354,9 +4354,9 @@ contains
              endif
           enddo  ! k
        endif  ! elem_cnct etc
-       
+
 !!!.......make intermediate points, lines, surfaces, at Xi2=1 for each 'ring' .........
-       
+
        ! location of points in the Xi+1 direction on the Xi2=1 boundary
        np_highest = elem_nodes_2d(3,ne)
        do k = 0,3
@@ -4364,7 +4364,7 @@ contains
           np2 = elem_nodes_2d(4,ne+k)
           nv1 = elem_versn_2d(3,ne+k)
           nv2 = elem_versn_2d(4,ne+k)
-          nk = 2 
+          nk = 2
           do i = 1,3
              phi_1_0 = 1.0_dp - 3.0_dp * xidivn(i)**2 + 2.0_dp * xidivn(i)**3
              phi_1_1 = xidivn(i) * (xidivn(i) - 1.0_dp)**2
@@ -4373,8 +4373,8 @@ contains
              forall (j=1:3) point_xyz(j) = phi_1_0 * node_xyz_2d(1,1,j,np1) &
                   + phi_2_0 * node_xyz_2d(1,1,j,np2) &
                   + phi_1_1 * node_xyz_2d(nk,nv1,j,np1) * scale_factors_2d(10,ne+k) &
-                  + phi_2_1 * node_xyz_2d(nk,nv2,j,np2) * scale_factors_2d(14,ne+k) 
-             
+                  + phi_2_1 * node_xyz_2d(nk,nv2,j,np2) * scale_factors_2d(14,ne+k)
+
              ncount_point = ncount_point + 1
              write(ifile,'(''Point('',i8,'') = {'',f12.7,'','',f12.7,'','',f12.7,'',lc};'')') &
                   ncount_point,point_xyz(1:3)
@@ -4386,7 +4386,7 @@ contains
           element_spline(3,ne+k) = ncount_spline
           if(elem_cnct_2d(2,0,ne+k).gt.0) element_spline(1,elem_cnct_2d(2,1,ne+k)) = ncount_spline
        enddo ! k
-       
+
        ! location of points in the Xi+2 direction on the Xi1=0 boundary
        do k = 0,3
           np1 = elem_nodes_2d(1,ne+k)
@@ -4403,7 +4403,7 @@ contains
                   + phi_2_0 * node_xyz_2d(1,1,j,np2) &
                   + phi_1_1 * node_xyz_2d(nk,nv1,j,np1) * scale_factors_2d(3,ne+k) &
                   + phi_2_1 * node_xyz_2d(nk,nv2,j,np2) * scale_factors_2d(11,ne+k)
-             
+
              ncount_point = ncount_point + 1
              write(ifile,'(''Point('',i8,'') = {'',f12.7,'','',f12.7,'','',f12.7,'',lc};'')') &
                   ncount_point,point_xyz(1:3)
@@ -4415,7 +4415,7 @@ contains
           element_spline(4,ne+k) = ncount_spline
           element_spline(2,elem_cnct_2d(-1,1,ne+k)) = ncount_spline
        enddo ! k
-       
+
        do k = 0,3
           line1 = element_spline(1,ne+k)
           line2 = element_spline(2,ne+k)
@@ -4428,17 +4428,17 @@ contains
           write(ifile,'(''Surface('',I8,'') = {'',I8,''};'')') ncount_loop, ncount_loop - 1
           elem_surfaces(3,ne+k) = ncount_loop
        enddo ! k
-       
+
        ne = ne + 4
-       
+
     enddo ! while (ne.le.num_elems_2d)
 
     deallocate(crux_lines)
-    
+
     call enter_exit(sub_name,2)
 
   end subroutine write_surface_geo
-  
+
 !!!#############################################################################
 
   subroutine write_3d_geo(element_spline,elem_surfaces,ifile,ncount_point, &
@@ -4455,19 +4455,19 @@ contains
          ncentre(:),ninner(:),nphys_vol(:),node_spoke(:,:),nwall(:)
     real(dp) :: point_xyz_centre(3), xidivn(3)
     character(len=60) :: sub_name
-    
+
     ! --------------------------------------------------------------------------
-    
+
     sub_name = 'write_3d_geo'
     call enter_exit(sub_name,1)
-        
+
     allocate(centre_points(num_nodes_2d))
     allocate(ncap_entry(20))  ! assuming could have multiple inlets
-    allocate(ncap_exit(num_elems_2d))  
-    allocate(ninner(num_elems_2d*2))  
+    allocate(ncap_exit(num_elems_2d))
+    allocate(ninner(num_elems_2d*2))
     allocate(ncentre(num_elems_2d))
     allocate(nphys_vol(num_elems_2d))
-    allocate(nwall(num_elems_2d))  
+    allocate(nwall(num_elems_2d))
     allocate(node_spoke(2,num_nodes_2d))
     node_spoke = 0
 
@@ -4478,7 +4478,7 @@ contains
 !!!....the following works on four adjacent surface elements
 
 !!!......... make intermediate points, lines, surfaces, at Xi2=0 for model entry .........
-       
+
        if((elem_cnct_2d(-2,0,ne).eq.0) .or. &
             (node_versn_2d(elem_nodes_2d(1,ne)).eq.6.or.&
             node_versn_2d(elem_nodes_2d(2,ne)).eq.6))then
@@ -4495,7 +4495,7 @@ contains
              ncount_point = ncount_point + 1
              write(ifile,'(''Point('',i8,'') = {'',f12.7,'','',f12.7,'','' &
                   &,f12.7,'',lc};'')') ncount_point,point_xyz_centre(1:3)
-             
+
              ! make a 'spoke' from centre of the ring to each surface node
              do k = 0,3
                 np1 = elem_nodes_2d(1,ne+k)
@@ -4508,7 +4508,7 @@ contains
 
              ! make surfaces at the entry == a 'cap' of four surfaces
              do k = 0,3
-                line1 = ncount_spline + k - 3 
+                line1 = ncount_spline + k - 3
                 line2 = element_spline(1,ne+k)
                 if(k.lt.3)then
                    line3 = -(line1 + 1)
@@ -4527,7 +4527,7 @@ contains
              enddo  ! k
           endif
        endif  ! elem_cnct etc
-       
+
 !!!......... make intermediate points, lines, surfaces, at Xi2=1 for each 'ring' .........
 
        ! location of points in the Xi+1 direction on the Xi2=1 boundary
@@ -4569,7 +4569,7 @@ contains
 
        if(node_versn_2d(np1).ge.2.or.node_versn_2d(np2).ge.2)then  ! only for when there is a crux node
           np_highest = elem_nodes_2d(2,elem_cnct_2d(1,1,elem_cnct_2d(2,1,ne)))
-          
+
           if(elems_at_node_2d(np_highest,0).eq.6)then
              do i = 1,elems_at_node_2d(np_highest,0)
                 ne_next = elems_at_node_2d(np_highest,i)
@@ -4610,7 +4610,7 @@ contains
           ncount_inner = ncount_inner + 1
           ninner(ncount_inner) = ncount_loop
        enddo  ! k
-             
+
        if(node_versn_2d(np1).ge.2.or.node_versn_2d(np2).ge.2)then  ! only for crux node
           ncount_spline = ncount_spline + 1
           write(ifile,'(''Line('',i8,'') = {'',i8,'','',i8,''};'')') &
@@ -4651,7 +4651,7 @@ contains
           elem_surfaces(1,ne_next) = ncount_loop
           ne_next = elem_cnct_2d(-2,1,ne_next)
           elem_surfaces(1,ne_next) = ncount_loop
-          
+
           if(elems_at_node_2d(np_highest,0).eq.6)then
              do i = 1,elems_at_node_2d(np_highest,0)
                 ne_next = elems_at_node_2d(np_highest,i)
@@ -4674,7 +4674,7 @@ contains
                    elem_surfaces(1,ne_next) = ncount_loop
                    ne_next = elem_cnct_2d(-2,1,ne_next)
                    elem_surfaces(1,ne_next) = ncount_loop
-                   
+
                    ne_next = elem_cnct_2d(1,1,ne_next)
                    np1 = elem_nodes_2d(1,ne_next)
                    np2 = elem_nodes_2d(2,ne_next)
@@ -4693,7 +4693,7 @@ contains
                    elem_surfaces(1,ne_next) = ncount_loop
                    ne_next = elem_cnct_2d(-2,1,ne_next)
                    elem_surfaces(1,ne_next) = ncount_loop
-                   
+
                 endif
              enddo
           endif
@@ -4732,7 +4732,7 @@ contains
           write(ifile,'(''Surface Loop('',i8,'') = {'',i8,'','' &
                &,i8,'','',i8,'','',i8,'','',i8,''};'')') &
                ncount_volume,elem_surfaces(1:5,ne+k)
-            
+
           ncount_volume = ncount_volume + 1
           write(ifile,'(''Volume('',i8,'') = {'',i8,''};'')') &
                ncount_volume,ncount_volume-1
@@ -4753,28 +4753,28 @@ contains
        write(ifile,'(i6,'','')', advance = "no") ncap_entry(i)
     enddo
     write(ifile,'(i6,''};'')') ncap_entry(ncount_cap_entry)
-    
+
     write(ifile,'(/''/* Physical surface for exit caps */'')')
     write(ifile,'(/''Physical Surface(2) = {'')', advance = "no")
     do i = 1,ncount_cap_exit-1
        write(ifile,'(i6,'','')', advance = "no") ncap_exit(i)
     enddo
     write(ifile,'(i6,''};'')') ncap_exit(ncount_cap_exit)
-    
+
     write(ifile,'(/''/* Physical surface for walls */'')')
     write(ifile,'(/''Physical Surface(3) = {'')', advance = "no")
     do i = 1,ncount_wall-1
        write(ifile,'(i6,'','')', advance = "no") nwall(i)
     enddo
     write(ifile,'(i6,''};'')') nwall(ncount_wall)
-    
+
     write(ifile,'(/''/* Physical surface for centres */'')')
     write(ifile,'(/''Physical Surface(4) = {'')', advance = "no")
     do i = 1,ncount_centre-1
        write(ifile,'(i6,'','')', advance = "no") ncentre(i)
     enddo
     write(ifile,'(i6,''};'')') ncentre(ncount_centre)
-    
+
     write(ifile,'(/''Physical Volume(1) = {'')', advance = "no")
     do i = 1,ncount_phys_vol-1
        write(ifile,'(i6,'','')', advance = "no") nphys_vol(i)
@@ -4798,9 +4798,9 @@ contains
     deallocate(node_spoke)
 
     call enter_exit(sub_name,2)
-    
+
   end subroutine write_3d_geo
 
 !!!#############################################################################
-  
+
 end module geometry


### PR DESCRIPTION
Fixing the elem numbering issue in export_1d_elem_field subroutine. This issue was exporting the field correctly but the elem numbers were jumping after artery elements to capillaries and potentially writing memory address to file since it was running out of memory allocated to elements. This pull request does not need changes to examples or tests.